### PR TITLE
fix: handle exact namespace matches in key resolution

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -337,7 +337,12 @@ func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, error) {
 
 	var fullKey string
 	if nsSource.Namespace != "" {
-		fullKey = nsSource.Namespace + cm.koanf.Delim() + namespacedKey
+		if namespacedKey == "" {
+			// If the key exactly matches a namespace, use it directly
+			fullKey = nsSource.Namespace
+		} else {
+			fullKey = nsSource.Namespace + cm.koanf.Delim() + namespacedKey
+		}
 	} else {
 		fullKey = key
 	}

--- a/manager_test.go
+++ b/manager_test.go
@@ -758,6 +758,75 @@ func (i *invalidSource) Watch(ctx context.Context, k *koanf.Koanf, cb source.Wat
 	return nil
 }
 
+func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
+	// Create a namespace that matches exactly one of our test keys
+	ns := "plugin.test_plugin.protocol"
+	memSource := source.NewMemoryConfigSource(map[string]any{
+		ns: "http",
+		"other.key": "value",
+	})
+
+	cm, err := NewConfigManager([]source.ConfigSource{memSource})
+	require.NoError(t, err)
+	
+	// Register the namespace
+	cm.RegisterNamespace(ns, memSource)
+	require.NoError(t, cm.Load())
+
+	tests := []struct {
+		name        string
+		key         string
+		wantErr     bool
+		wantValue   any
+		errContains string
+	}{
+		{
+			name:      "exact namespace match",
+			key:       ns,
+			wantValue: "http",
+		},
+		{
+			name:      "nested key under namespace",
+			key:       ns + ".subkey",
+			wantErr:   true,
+			errContains: "not found",
+		},
+		{
+			name:        "double dot at end",
+			key:         ns + "..",
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name:        "double dot in middle",
+			key:         "plugin..test_plugin.protocol",
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name:      "non-namespaced key",
+			key:       "other.key",
+			wantValue: "value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := cm.Get(tt.key)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				assert.Nil(t, val)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantValue, val)
+			}
+		})
+	}
+}
+
 func TestConfigManager_ValidateWithZogSchema(t *testing.T) {
 	cm, _ := NewConfigManager([]source.ConfigSource{})
 	logger := zap.NewNop()


### PR DESCRIPTION
- Modified namespace key resolution to handle exact namespace matches without adding delimiter when namespacedKey is empty
- Added comprehensive test cases for namespace key handling including:
  - Exact namespace matches
  - Nested keys under namespace
  - Edge cases with double dots
  - Non-namespaced keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration key handling to ensure correct retrieval when a key exactly matches a registered namespace.
- **Tests**
  - Added tests to verify correct behavior for namespace-matching keys and edge cases in configuration retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->