### PR TITLE
refactor: enhance Get method to return both raw and decoded values

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ type Manager interface {
 	FlagManager() FlagManager
 
 	// Configuration access
-	Get(key string, target ...any) (any, error)
+	Get(key string, target ...any) (any, any, error)
 	GetString(key string) (string, error)
 	GetInt(key string) (int64, error)
 	GetBool(key string) (bool, error)

--- a/manager.go
+++ b/manager.go
@@ -276,7 +276,7 @@ func (cm *ConfigManagerDefault) Load() error {
 
 // GetString returns the string value for the given key.
 func (cm *ConfigManagerDefault) GetString(key string) (string, error) {
-	val, err := cm.Get(key)
+	val, _, err := cm.Get(key)
 	if err != nil {
 		return "", err
 	}
@@ -285,7 +285,7 @@ func (cm *ConfigManagerDefault) GetString(key string) (string, error) {
 
 // GetInt returns the int64 value for the given key.
 func (cm *ConfigManagerDefault) GetInt(key string) (int64, error) {
-	val, err := cm.Get(key)
+	val, _, err := cm.Get(key)
 	if err != nil {
 		return 0, err
 	}
@@ -294,7 +294,7 @@ func (cm *ConfigManagerDefault) GetInt(key string) (int64, error) {
 
 // GetBool returns the bool value for the given key.
 func (cm *ConfigManagerDefault) GetBool(key string) (bool, error) {
-	val, err := cm.Get(key)
+	val, _, err := cm.Get(key)
 	if err != nil {
 		return false, err
 	}
@@ -303,7 +303,7 @@ func (cm *ConfigManagerDefault) GetBool(key string) (bool, error) {
 
 // GetDuration returns the time.Duration value for the given key.
 func (cm *ConfigManagerDefault) GetDuration(key string) (time.Duration, error) {
-	val, err := cm.Get(key)
+	val, _, err := cm.Get(key)
 	if err != nil {
 		return 0, err
 	}
@@ -312,7 +312,7 @@ func (cm *ConfigManagerDefault) GetDuration(key string) (time.Duration, error) {
 
 // GetStringSlice returns the []string value for the given key.
 func (cm *ConfigManagerDefault) GetStringSlice(key string) ([]string, error) {
-	val, err := cm.Get(key)
+	val, _, err := cm.Get(key)
 	if err != nil {
 		return nil, err
 	}
@@ -329,16 +329,17 @@ func (cm *ConfigManagerDefault) IsSet(ctx context.Context, key string) bool {
 }
 
 // Get returns the configuration value for the given key.
-// If target is provided and a struct is registered for the key, the value will be decoded into the target.
-// It prioritizes the most specific namespace when looking up keys.
-func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, error) {
+// Returns:
+// - raw any: direct config value from koanf
+// - decoded any: populated struct if target provided, new struct instance if registered, otherwise same as raw
+// - error: if any occurred
+func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, any, error) {
 	// Find the most specific namespace for this key
 	nsSource, namespacedKey := cm.registry.FindMostSpecificNamespace(key, cm.koanf.Delim())
 
 	var fullKey string
 	if nsSource.Namespace != "" {
 		if namespacedKey == "" {
-			// If the key exactly matches a namespace, use it directly
 			fullKey = nsSource.Namespace
 		} else {
 			fullKey = nsSource.Namespace + cm.koanf.Delim() + namespacedKey
@@ -347,16 +348,26 @@ func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, error) {
 		fullKey = key
 	}
 
-	// Check if we should decode into a struct
-	if len(target) > 0 {
-		return cm.getIntoStruct(fullKey, target[0])
-	}
-
-	// Fall back to basic get
+	// Get raw value first
 	if !cm.koanf.Exists(fullKey) {
-		return nil, fmt.Errorf("configuration key '%s' not found", fullKey)
+		return nil, nil, fmt.Errorf("configuration key '%s' not found", fullKey)
 	}
-	return cm.koanf.Get(fullKey), nil
+	raw := cm.koanf.Get(fullKey)
+
+	// Handle struct decoding cases
+	switch {
+	case len(target) > 0:
+		// Decode into provided target
+		decoded, err := cm.getIntoStruct(fullKey, target[0])
+		return raw, decoded, err
+	case cm.hasConfigStruct(fullKey):
+		// Decode into new struct instance
+		decoded, err := cm.getIntoStruct(fullKey, nil)
+		return raw, decoded, err
+	default:
+		// No struct decoding needed
+		return raw, raw, nil
+	}
 }
 
 // getIntoStruct decodes configuration into a registered struct type (used by RegisterStruct)
@@ -380,7 +391,7 @@ func (cm *ConfigManagerDefault) getIntoStruct(key string, target any) (any, erro
 	} else {
 		// Get the actual type of target (handling pointers)
 		targetType := reflect.TypeOf(target)
-		
+
 		// Allow both pointer and value targets as long as underlying type matches
 		var targetElemType reflect.Type
 		if targetType.Kind() == reflect.Ptr {
@@ -390,8 +401,8 @@ func (cm *ConfigManagerDefault) getIntoStruct(key string, target any) (any, erro
 		}
 
 		// Check if registered type matches target type (handling both pointer and value cases)
-		if targetElemType != structType && 
-		   !(structType.Kind() == reflect.Ptr && structType.Elem() == targetElemType) {
+		if targetElemType != structType &&
+			!(structType.Kind() == reflect.Ptr && structType.Elem() == targetElemType) {
 			return nil, fmt.Errorf("target type %v does not match registered type %v",
 				targetType, structType)
 		}
@@ -405,7 +416,6 @@ func (cm *ConfigManagerDefault) getIntoStruct(key string, target any) (any, erro
 			cfg = target
 		}
 	}
-
 
 	hooks := []mapstructure.DecodeHookFunc{
 		mapstructure.StringToTimeDurationHookFunc(),
@@ -533,7 +543,13 @@ func (cm *ConfigManagerDefault) SetAtomic(ctx context.Context, updates map[strin
 			return fmt.Errorf("validation failed for struct %s: %w", structKey, err)
 		}
 
-		oldValue, _ := cm.Get(structKey)
+		oldValue, _, err := cm.Get(structKey)
+		if err != nil {
+			cm.logger.Error("failed to get old value for struct during atomic update",
+				zap.String("key", structKey),
+				zap.Error(err))
+			continue
+		}
 		cm.notifySubscribers(structKey, oldValue, newStruct)
 	}
 
@@ -694,7 +710,7 @@ func (cm *ConfigManagerDefault) validateConfig(key string) error {
 
 	// Check if we have a registered struct for this key
 	if cm.hasConfigStruct(key) {
-		cfg, err := cm.Get(key)
+		cfg, _, err := cm.Get(key)
 		if err != nil {
 			return fmt.Errorf("failed to get config for validation: %w", err)
 		}
@@ -709,8 +725,7 @@ func (cm *ConfigManagerDefault) validateConfig(key string) error {
 	}
 
 	// Get the parent struct (decoded into its registered type) and validate it
-	var parentStruct any
-	parentStruct, err := cm.Get(parentKey, nil)
+	_, parentStruct, err := cm.Get(parentKey)
 	if err != nil {
 		return fmt.Errorf("failed to get parent config for validation: %w", err)
 	}

--- a/manager_test.go
+++ b/manager_test.go
@@ -72,9 +72,10 @@ func TestNewConfigManager(t *testing.T) {
 	assert.NotNil(t, cm.configStructs)
 
 	// Verify memory source was loaded
-	val, err := cm.Get("test.key")
+	raw, decoded, err := cm.Get("test.key")
 	assert.NoError(t, err)
-	assert.Equal(t, "test_value", val)
+	assert.Equal(t, "test_value", raw)
+	assert.Equal(t, "test_value", decoded)
 }
 
 func TestConfigManager_WildcardSubscriptions(t *testing.T) {
@@ -210,31 +211,36 @@ func TestConfigManager_SetGetExists(t *testing.T) {
 	// Test Set and Get with string
 	err := cm.Set(context.Background(), "test.string", "test_value")
 	assert.NoError(t, err)
-	val, err := cm.Get("test.string")
+	raw, decoded, err := cm.Get("test.string")
 	assert.NoError(t, err)
-	assert.Equal(t, "test_value", val)
+	assert.Equal(t, "test_value", raw)
+	assert.Equal(t, "test_value", decoded)
 
 	// Test Set and Get with int
 	err = cm.Set(context.Background(), "test.int", 123)
 	assert.NoError(t, err)
-	val, err = cm.Get("test.int")
+	raw, decoded, err = cm.Get("test.int")
 	assert.NoError(t, err)
-	assert.Equal(t, 123, val)
+	assert.Equal(t, 123, raw)
+	assert.Equal(t, 123, decoded)
 
 	// Test Set and Get with bool
 	err = cm.Set(context.Background(), "test.bool", true)
 	assert.NoError(t, err)
-	val, err = cm.Get("test.bool")
+	raw, decoded, err = cm.Get("test.bool")
 	assert.NoError(t, err)
-	assert.Equal(t, true, val)
+	assert.Equal(t, true, raw)
+	assert.Equal(t, true, decoded)
 
 	// Test Exists
 	assert.True(t, cm.Exists("test.string"))
 	assert.False(t, cm.Exists("nonexistent.key"))
 
 	// Test Get non-existent key
-	_, err = cm.Get("nonexistent.key")
+	raw, decoded, err = cm.Get("nonexistent.key")
 	assert.Error(t, err)
+	assert.Nil(t, raw)
+	assert.Nil(t, decoded)
 }
 
 func TestConfigManager_All(t *testing.T) {
@@ -258,12 +264,14 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Set values
-		cm.Set(context.Background(), "test.struct.string_value", "struct_string")
-		cm.Set(context.Background(), "test.struct.int_value", 456)
+		err = cm.Set(context.Background(), "test.struct.string_value", "struct_string")
+		assert.NoError(t, err)
+		err = cm.Set(context.Background(), "test.struct.int_value", 456)
+		assert.NoError(t, err)
 
 		// Get with pointer target
 		var targetCfg TestConfig
-		cfg, err := cm.Get("test.struct", &targetCfg)
+		_, cfg, err := cm.Get("test.struct", &targetCfg)
 		assert.NoError(t, err)
 		assert.IsType(t, &TestConfig{}, cfg)
 		assert.Equal(t, "struct_string", cfg.(*TestConfig).StringValue)
@@ -274,13 +282,15 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		err := cm.RegisterStruct("test.struct", TestConfig{})
 		assert.NoError(t, err)
 
-		cm.Set(context.Background(), "test.struct.string_value", "nil_target")
+		err = cm.Set(context.Background(), "test.struct.string_value", "nil_target")
+		assert.NoError(t, err)
 
 		// Get with nil target
-		cfg, err := cm.Get("test.struct", nil)
+		raw, decoded, err := cm.Get("test.struct", nil)
 		assert.NoError(t, err)
-		assert.IsType(t, &TestConfig{}, cfg)
-		assert.Equal(t, "nil_target", cfg.(*TestConfig).StringValue)
+		assert.IsType(t, map[string]interface{}{}, raw)
+		assert.IsType(t, &TestConfig{}, decoded)
+		assert.Equal(t, "nil_target", decoded.(*TestConfig).StringValue)
 	})
 
 	t.Run("value registration with value target", func(t *testing.T) {
@@ -288,11 +298,12 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		err := cm.RegisterStruct("test.struct", TestConfig{})
 		assert.NoError(t, err)
 
-		cm.Set(context.Background(), "test.struct.string_value", "value_target")
+		err = cm.Set(context.Background(), "test.struct.string_value", "value_target")
+		assert.NoError(t, err)
 
 		// This should fail since we can't set into a value target
 		var targetCfg TestConfig
-		_, err = cm.Get("test.struct", targetCfg)
+		_, _, err = cm.Get("test.struct", targetCfg)
 		assert.Error(t, err)
 	})
 
@@ -305,10 +316,11 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		cm.Set(context.Background(), "test.struct.string_value", "pointer_reg")
 
 		var targetCfg TestConfig
-		cfg, err := cm.Get("test.struct", &targetCfg)
+		raw, decoded, err := cm.Get("test.struct", &targetCfg)
 		assert.NoError(t, err)
-		assert.IsType(t, &TestConfig{}, cfg)
-		assert.Equal(t, "pointer_reg", cfg.(*TestConfig).StringValue)
+		assert.IsType(t, map[string]interface{}{}, raw)
+		assert.IsType(t, &TestConfig{}, decoded)
+		assert.Equal(t, "pointer_reg", decoded.(*TestConfig).StringValue)
 	})
 
 	t.Run("pointer registration with nil target", func(t *testing.T) {
@@ -316,12 +328,14 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		err := cm.RegisterStruct("test.struct", &TestConfig{})
 		assert.NoError(t, err)
 
-		cm.Set(context.Background(), "test.struct.string_value", "nil_ptr_target")
-
-		cfg, err := cm.Get("test.struct", nil)
+		err = cm.Set(context.Background(), "test.struct.string_value", "nil_ptr_target")
 		assert.NoError(t, err)
-		assert.IsType(t, &TestConfig{}, cfg)
-		assert.Equal(t, "nil_ptr_target", cfg.(*TestConfig).StringValue)
+
+		raw, decoded, err := cm.Get("test.struct", nil)
+		assert.NoError(t, err)
+		assert.IsType(t, map[string]interface{}{}, raw)
+		assert.IsType(t, &TestConfig{}, decoded)
+		assert.Equal(t, "nil_ptr_target", decoded.(*TestConfig).StringValue)
 	})
 
 	t.Run("type mismatch detection", func(t *testing.T) {
@@ -329,12 +343,18 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		err := cm.RegisterStruct("test.struct", TestConfig{})
 		assert.NoError(t, err)
 
+		// Set some data first
+		err = cm.Set(context.Background(), "test.struct.string_value", "test_value")
+		assert.NoError(t, err)
+		err = cm.Set(context.Background(), "test.struct.int_value", 123)
+		assert.NoError(t, err)
+
 		type MismatchConfig struct {
 			Different string `config:"different"`
 		}
 
 		var target MismatchConfig
-		_, err = cm.Get("test.struct", &target)
+		_, _, err = cm.Get("test.struct", &target)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not match registered type")
 	})
@@ -386,7 +406,7 @@ func TestConfigManager_TypeConversions(t *testing.T) {
 
 	// Get the struct
 	var cfg ConversionTestStruct
-	_, err = cm.Get("test.conversions", &cfg)
+	_, _, err = cm.Get("test.conversions", &cfg)
 	assert.NoError(t, err)
 
 	// Verify conversions
@@ -426,7 +446,7 @@ func TestConfigManager_NestedStructConversions(t *testing.T) {
 
 	// Get the struct
 	var cfg ParentStruct
-	_, err = cm.Get("test.nested", &cfg)
+	_, _, err = cm.Get("test.nested", &cfg)
 	assert.NoError(t, err)
 
 	// Verify conversions
@@ -467,9 +487,9 @@ func TestConfigManager_SetAtomic(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify values
-	val, _ := cm.Get("test.string")
+	val, _, _ := cm.Get("test.string")
 	assert.Equal(t, "updated_string", val)
-	val, _ = cm.Get("test.int")
+	val, _, _ = cm.Get("test.int")
 	assert.Equal(t, 456, val)
 }
 
@@ -575,9 +595,10 @@ func TestConfigManager_Validate(t *testing.T) {
 			"validation should fail with expected error")
 
 		// Verify the value was not changed by validation
-		val, err := cm.Get("test.always_invalid.value")
+		raw, decoded, err := cm.Get("test.always_invalid.value")
 		assert.NoError(t, err)
-		assert.Equal(t, "initial", val, "validation failure should not modify the value")
+		assert.Equal(t, "initial", raw, "validation failure should not modify the value")
+		assert.Equal(t, "initial", decoded, "validation failure should not modify the value")
 	})
 
 	t.Run("conditional validation - valid case", func(t *testing.T) {
@@ -812,13 +833,13 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 	// Create a namespace that matches exactly one of our test keys
 	ns := "plugin.test_plugin.protocol"
 	memSource := source.NewMemoryConfigSource(map[string]any{
-		ns: "http",
+		ns:          "http",
 		"other.key": "value",
 	})
 
 	cm, err := NewConfigManager([]source.ConfigSource{memSource})
 	require.NoError(t, err)
-	
+
 	// Register the namespace
 	cm.RegisterNamespace(ns, memSource)
 	require.NoError(t, cm.Load())
@@ -836,9 +857,9 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 			wantValue: "http",
 		},
 		{
-			name:      "nested key under namespace",
-			key:       ns + ".subkey",
-			wantErr:   true,
+			name:        "nested key under namespace",
+			key:         ns + ".subkey",
+			wantErr:     true,
 			errContains: "not found",
 		},
 		{
@@ -862,7 +883,7 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val, err := cm.Get(tt.key)
+			val, _, err := cm.Get(tt.key)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {
@@ -903,9 +924,10 @@ func TestConfigManager_ValidateWithZogSchema(t *testing.T) {
 		assert.Contains(t, err.Error(), "valid") // Check for validation keyword
 
 		// Verify the invalid value wasn't actually set
-		val, err := cm.Get("test.schema.email")
+		raw, decoded, err := cm.Get("test.schema.email")
 		assert.NoError(t, err)
-		assert.NotEqual(t, "invalid-email", val)
+		assert.NotEqual(t, "invalid-email", raw)
+		assert.NotEqual(t, "invalid-email", decoded)
 	})
 
 	t.Run("weak password fails schema validation", func(t *testing.T) {
@@ -918,9 +940,10 @@ func TestConfigManager_ValidateWithZogSchema(t *testing.T) {
 		assert.Contains(t, err.Error(), "digit")     // Check for digit requirement
 
 		// Verify the invalid value wasn't actually set
-		val, err := cm.Get("test.schema.password")
+		raw, decoded, err := cm.Get("test.schema.password")
 		assert.NoError(t, err)
-		assert.NotEqual(t, "weak", val)
+		assert.NotEqual(t, "weak", raw)
+		assert.NotEqual(t, "weak", decoded)
 	})
 
 	t.Run("partial validation shows all errors", func(t *testing.T) {
@@ -943,12 +966,14 @@ func TestConfigManager_ValidateWithZogSchema(t *testing.T) {
 			"error should mention either uppercase or digit requirement")
 
 		// Verify original valid values remain unchanged
-		email, err := cm.Get("test.schema.email")
+		raw, decoded, err := cm.Get("test.schema.email")
 		assert.NoError(t, err)
-		assert.Equal(t, "valid@example.com", email)
+		assert.Equal(t, "valid@example.com", raw)
+		assert.Equal(t, "valid@example.com", decoded)
 
-		pass, err := cm.Get("test.schema.password")
+		raw, decoded, err = cm.Get("test.schema.password")
 		assert.NoError(t, err)
-		assert.Equal(t, "Valid1234", pass)
+		assert.Equal(t, "Valid1234", raw)
+		assert.Equal(t, "Valid1234", decoded)
 	})
 }

--- a/sync/dummy_test.go
+++ b/sync/dummy_test.go
@@ -216,6 +216,6 @@ func (m *mockManager) Push(ctx context.Context, key string, value any, callback 
 func (m *mockManager) Configure(manager configManager, namespace string) error {
 	return nil
 }
-func (m *mockManager) Get(key string, target ...any) (any, error) {
-	return nil, nil
+func (m *mockManager) Get(key string, target ...any) (any, any, error) {
+	return nil, nil, nil
 }

--- a/sync/etcd.go
+++ b/sync/etcd.go
@@ -61,7 +61,7 @@ func (e *EtcdSyncClient) Configure(manager configManager, namespace string, opts
 
 	// Get etcd config from manager
 	var etcdConfig config.EtcdConfig
-	if _, err := manager.Get(namespace, &etcdConfig); err != nil {
+	if _, _, err := manager.Get(namespace, &etcdConfig); err != nil {
 		return fmt.Errorf("failed to get etcd config from manager: %w", err)
 	}
 

--- a/sync/etcd_test.go
+++ b/sync/etcd_test.go
@@ -177,12 +177,12 @@ type mockConfigManager struct {
 	data map[string]any
 }
 
-func (m *mockConfigManager) Get(key string, target ...any) (any, error) {
+func (m *mockConfigManager) Get(key string, target ...any) (any, any, error) {
 	val, ok := m.data[key]
 	if !ok {
-		return nil, fmt.Errorf("key not found")
+		return nil, nil, fmt.Errorf("key not found")
 	}
-	return val, nil
+	return val, nil, nil
 }
 
 func (m *mockConfigManager) Start(ctx context.Context) error { return nil }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -31,7 +31,7 @@ type Manager interface {
 	Configure(manager configManager, namespace string, opts ...SyncOption) error
 }
 type configManager interface {
-	Get(key string, target ...any) (any, error)
+	Get(string, ...any) (any, any, error)
 }
 
 type CManager = configManager


### PR DESCRIPTION
- Modified ConfigManager's Get method signature to return (any, any, error) where first return is raw config value and second is decoded struct (if applicable)
- Updated all Get method calls throughout codebase to handle new return signature
- Adjusted tests to verify both raw and decoded values where appropriate
- Ensured backward compatibility with existing config struct decoding behavior
- Improved documentation for Get method to clarify return values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the configuration retrieval method to return both raw and decoded values, along with error information, across the application.
  - Adjusted all related interfaces and test code to accommodate the new method signature.
- **Tests**
  - Modified test cases to verify both raw and decoded configuration values.
  - Improved error handling and formatting in test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->