### PR TITLE
refactor: update config manager interface and implementations

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,11 +46,13 @@ type Manager interface {
 	// Configuration modification
 	Set(ctx context.Context, key string, value any) error
 	SetAtomic(ctx context.Context, updates map[string]any) error
+	Delete(key string)
 
 	// Change notifications
 	Subscribe(pattern string, callback SubscriptionCallback) func()
 
 	// Key Management
+	Keys() []string
 	ListKeys(prefix string) []string
 
 	// File paths
@@ -73,4 +75,7 @@ type Manager interface {
 
 	// Sync management
 	SetupSync(opts ...ConfigOption) error
+
+	// Delimiter access
+	Delim() string
 }

--- a/manager.go
+++ b/manager.go
@@ -40,6 +40,7 @@ type ConfigManagerDefault struct {
 	tagName          string
 	registry         ConfigRegistry
 	syncConfigNS     string // Namespace for sync client configuration
+	delimiter        string // Custom delimiter for nested keys
 }
 
 // Ensure ConfigManagerDefault implements Manager interface
@@ -78,7 +79,7 @@ func (cm *ConfigManagerDefault) Subscribe(pattern string, callback SubscriptionC
 
 // reloadConfig reloads configuration from a source
 func (cm *ConfigManagerDefault) reloadConfig(ctx context.Context, source source.ConfigSource) error {
-	if err := source.Load(ctx, cm.koanf); err != nil {
+	if err := source.Load(ctx, cm); err != nil {
 		return fmt.Errorf("failed to reload config: %w", err)
 	}
 	return nil
@@ -92,7 +93,7 @@ func (cm *ConfigManagerDefault) handleConfigChanges(_source source.ConfigSource,
 
 	if len(changedKeys) == 1 && changedKeys[0] == source.WatchAllChanges {
 		// All config may have changed, reload the entire source
-		if err := _source.Load(context.Background(), cm.koanf); err != nil {
+		if err := _source.Load(context.Background(), cm); err != nil {
 			cm.logger.Error("Failed to reload configuration from source",
 				zap.String("source", fmt.Sprintf("%T", _source)),
 				zap.Error(err))
@@ -120,12 +121,12 @@ func (cm *ConfigManagerDefault) reloadKey(ctx context.Context, source source.Con
 
 	// Get the old value before updating
 	var oldValue any
-	if cm.koanf.Exists(key) {
-		oldValue = cm.koanf.Get(key)
+	if cm.Exists(key) {
+		oldValue, _, _ = cm.Get(key)
 	}
 
 	// Update the value in Koanf
-	if err := cm.koanf.Set(key, newValue); err != nil {
+	if err := cm.Set(ctx, key, newValue); err != nil {
 		return fmt.Errorf("failed to set new value for key %s in koanf: %w", key, err)
 	}
 
@@ -136,19 +137,17 @@ func (cm *ConfigManagerDefault) reloadKey(ctx context.Context, source source.Con
 }
 
 func (cm *ConfigManagerDefault) getKeyFromSource(ctx context.Context, source source.ConfigSource, key string) (any, error) {
-	// Create a temporary Koanf instance
-	tmpKoanf := koanf.New(".")
 
-	// Load only the specific key from the source into the temporary Koanf instance
-	if err := source.Load(ctx, tmpKoanf); err != nil {
+	// Load only the specific key from the source
+	if err := source.Load(ctx, cm); err != nil {
 		return nil, fmt.Errorf("failed to load config from source: %w", err)
 	}
 
-	// Get the value of the key from the temporary Koanf instance
-	if !tmpKoanf.Exists(key) {
+	// Get the value of the key
+	if !cm.Exists(key) {
 		return nil, fmt.Errorf("key %s not found in source", key)
 	}
-	return tmpKoanf.Get(key), nil
+	return cm.koanf.Get(key), nil
 }
 
 func (cm *ConfigManagerDefault) notifySubscribers(key string, oldValue any, newValue any) {
@@ -165,12 +164,22 @@ func (cm *ConfigManagerDefault) notifySubscribers(key string, oldValue any, newV
 	}
 }
 
+// WithDelimiter sets the delimiter used for nested keys in the configuration manager.
+func WithDelimiter(delimiter string) ConfigOption {
+	return func(cm *ConfigManagerDefault) error {
+		cm.delimiter = delimiter
+		cm.koanf = koanf.New(delimiter)
+		return nil
+	}
+}
+
 // NewConfigManager creates a new ConfigManagerDefault.
 // Sources can be:
 // - string paths (automatically wrapped as file sources)
 // - source.ConfigSource implementations
 // - []source.ConfigSource slice
 func NewConfigManager(sources any, opts ...ConfigOption) (*ConfigManagerDefault, error) {
+	// Create with default delimiter first
 	k := koanf.New(".")
 	eventMgr := event.NewManager[csync.ConfigEvent]("", event.UsePathMode)
 
@@ -257,12 +266,12 @@ func (cm *ConfigManagerDefault) SetupSync(opts ...ConfigOption) error {
 // Load loads the initial configuration from the configured sources.
 func (cm *ConfigManagerDefault) Load() error {
 	for _, _source := range cm.sources {
-		if err := _source.Load(context.Background(), cm.koanf); err != nil {
+		if err := _source.Load(context.Background(), cm); err != nil {
 			return fmt.Errorf("failed to load config from source: %w", err)
 		}
 
 		// Start watching for changes if the source supports it
-		if err := _source.Watch(context.Background(), cm.koanf, func(changedKeys []string, err error) {
+		if err := _source.Watch(context.Background(), cm, func(changedKeys []string, err error) {
 			cm.handleConfigChanges(_source, changedKeys)
 		}); err != nil {
 			cm.logger.Warn("failed to start config watcher",
@@ -324,7 +333,7 @@ func (cm *ConfigManagerDefault) IsSet(ctx context.Context, key string) bool {
 	if !cm.Exists(key) {
 		return false
 	}
-	val := cm.koanf.Get(key)
+	val, _, _ := cm.Get(key)
 	return !reflect.ValueOf(val).IsZero()
 }
 
@@ -335,14 +344,14 @@ func (cm *ConfigManagerDefault) IsSet(ctx context.Context, key string) bool {
 // - error: if any occurred
 func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, any, error) {
 	// Find the most specific namespace for this key
-	nsSource, namespacedKey := cm.registry.FindMostSpecificNamespace(key, cm.koanf.Delim())
+	nsSource, namespacedKey := cm.registry.FindMostSpecificNamespace(key, cm.Delim())
 
 	var fullKey string
 	if nsSource.Namespace != "" {
 		if namespacedKey == "" {
 			fullKey = nsSource.Namespace
 		} else {
-			fullKey = nsSource.Namespace + cm.koanf.Delim() + namespacedKey
+			fullKey = nsSource.Namespace + cm.Delim() + namespacedKey
 		}
 	} else {
 		fullKey = key
@@ -514,7 +523,12 @@ func (cm *ConfigManagerDefault) SetAtomic(ctx context.Context, updates map[strin
 
 	// First pass: collect old values and identify affected structs
 	for key := range updates {
-		oldValues[key] = cm.koanf.Get(key)
+		raw, _, err := cm.Get(key)
+		if err != nil {
+			oldValues[key] = nil
+		} else {
+			oldValues[key] = raw
+		}
 		structKey := cm.findNearestStructKey(key)
 		if structKey != "" {
 			structKeys[structKey] = struct{}{}
@@ -523,7 +537,7 @@ func (cm *ConfigManagerDefault) SetAtomic(ctx context.Context, updates map[strin
 
 	// Second pass: apply all updates
 	for key, value := range updates {
-		if err := cm.koanf.Set(key, value); err != nil {
+		if err := cm.Set(ctx, key, value); err != nil {
 			return fmt.Errorf("failed to set config value for key %s: %w", key, err)
 		}
 	}
@@ -538,7 +552,7 @@ func (cm *ConfigManagerDefault) SetAtomic(ctx context.Context, updates map[strin
 		if err := cm.validateValue(structKey, newStruct); err != nil {
 			// Revert all changes if validation fails
 			for key, oldValue := range oldValues {
-				_ = cm.koanf.Set(key, oldValue)
+				_ = cm.Set(ctx, key, oldValue)
 			}
 			return fmt.Errorf("validation failed for struct %s: %w", structKey, err)
 		}
@@ -577,9 +591,9 @@ func (cm *ConfigManagerDefault) SetAtomic(ctx context.Context, updates map[strin
 // Set sets the configuration value for the given key.
 func (cm *ConfigManagerDefault) Set(ctx context.Context, key string, value any) error {
 	// Get the old value before updating
-	oldValue := cm.koanf.Get(key)
+	oldValue, _, _ := cm.Get(key)
 
-	// Set the new value
+	// Set the new value in koanf
 	if err := cm.koanf.Set(key, value); err != nil {
 		return fmt.Errorf("failed to set config value in koanf: %w", err)
 	}
@@ -598,7 +612,9 @@ func (cm *ConfigManagerDefault) Set(ctx context.Context, key string, value any) 
 				// Update and validate the associated struct
 				newStruct, err := cm.getIntoStruct(structKey, nil)
 				if err != nil {
-					cm.logger.Error("failed to decode struct for key %s", zap.String("key", structKey), zap.Error(err))
+					cm.logger.Error("failed to decode struct for key",
+						zap.String("key", structKey),
+						zap.Error(err))
 					// Revert the change if validation fails
 					_ = cm.koanf.Set(key, oldValue)
 					return
@@ -608,7 +624,9 @@ func (cm *ConfigManagerDefault) Set(ctx context.Context, key string, value any) 
 				if err := cm.validateValue(structKey, newStruct); err != nil {
 					// Revert the change if validation fails
 					_ = cm.koanf.Set(key, oldValue)
-					cm.logger.Error("validation failed for struct %s", zap.String("key", structKey), zap.Error(err))
+					cm.logger.Error("validation failed for struct",
+						zap.String("key", structKey),
+						zap.Error(err))
 					return
 				}
 
@@ -651,10 +669,10 @@ func (cm *ConfigManagerDefault) Set(ctx context.Context, key string, value any) 
 // getFilteredKeys returns keys filtered by prefixes if provided, otherwise all keys
 func (cm *ConfigManagerDefault) getFilteredKeys(keyPrefix ...string) []string {
 	if len(keyPrefix) == 0 {
-		return cm.koanf.Keys()
+		return cm.Keys()
 	}
 
-	allKeys := cm.koanf.Keys()
+	allKeys := cm.Keys()
 	return lo.FlatMap(keyPrefix, func(prefix string, _ int) []string {
 		return lo.Filter(allKeys, func(key string, _ int) bool {
 			return strings.HasPrefix(key, prefix+keySeparator)
@@ -721,7 +739,11 @@ func (cm *ConfigManagerDefault) validateConfig(key string) error {
 	parentKey := cm.findNearestStructKey(key)
 	if parentKey == "" {
 		// No parent struct, just validate the raw value
-		return cm.validateValue(key, cm.koanf.Get(key))
+		raw, _, err := cm.Get(key)
+		if err != nil {
+			return err
+		}
+		return cm.validateValue(key, raw)
 	}
 
 	// Get the parent struct (decoded into its registered type) and validate it
@@ -812,7 +834,7 @@ func (cm *ConfigManagerDefault) Persist(keyPrefix ...string) error {
 			})
 
 			if len(persistKeys) > 0 {
-				if err := ps.Persist(cm.koanf, persistKeys...); err != nil {
+				if err := ps.Persist(cm, persistKeys...); err != nil {
 					cm.logger.Error("failed to persist config for a source", zap.Error(err))
 					if accumulatedError == nil {
 						accumulatedError = fmt.Errorf("error persisting source: %w", err)
@@ -949,9 +971,36 @@ func (cm *ConfigManagerDefault) findNearestStructKey(key string) string {
 	return ""
 }
 
+// Keys returns all configuration keys
+func (cm *ConfigManagerDefault) Keys() []string {
+	return cm.koanf.Keys()
+}
+
 // ListKeys returns all configuration keys matching the given prefix
 func (cm *ConfigManagerDefault) ListKeys(prefix string) []string {
 	return cm.getFilteredKeys(prefix)
+}
+
+// Delete removes a configuration key and notifies watchers
+func (cm *ConfigManagerDefault) Delete(key string) {
+	// Get the old value before deleting
+	var oldValue any
+	if cm.Exists(key) {
+		oldValue = cm.koanf.Get(key)
+	}
+
+	cm.koanf.Delete(key)
+
+	// Notify watchers of the deletion
+	cm.notifySubscribers(key, oldValue, nil)
+}
+
+// Delim returns the delimiter used for nested keys
+func (cm *ConfigManagerDefault) Delim() string {
+	if cm.delimiter != "" {
+		return cm.delimiter
+	}
+	return cm.koanf.Delim()
 }
 
 // ConfigFile returns the path to the configuration file
@@ -991,14 +1040,14 @@ func (cm *ConfigManagerDefault) LoadSource(src source.ConfigSource, load bool, w
 
 	// Load the source if requested
 	if load {
-		if err := src.Load(context.Background(), cm.koanf); err != nil {
+		if err := src.Load(context.Background(), cm); err != nil {
 			return fmt.Errorf("failed to load source: %w", err)
 		}
 	}
 
 	// Start watching if requested and supported
 	if watch {
-		if err := src.Watch(context.Background(), cm.koanf, func(changedKeys []string, err error) {
+		if err := src.Watch(context.Background(), cm, func(changedKeys []string, err error) {
 			cm.handleConfigChanges(src, changedKeys)
 		}); err != nil {
 			cm.logger.Warn("failed to start watching source",
@@ -1033,7 +1082,7 @@ func (cm *ConfigManagerDefault) UnregisterNamespace(namespace string) error {
 	cm.registry.Unregister(namespace)
 
 	// Delete all keys under this namespace from the main koanf
-	cm.koanf.Delete(namespace)
+	cm.Delete(namespace)
 
 	return nil
 }
@@ -1055,21 +1104,13 @@ func (cm *ConfigManagerDefault) LoadNamespace(namespace string) error {
 		return fmt.Errorf("namespace %s not registered", namespace)
 	}
 
-	// Create a temporary Koanf instance for this namespace
-	tmpKoanf := koanf.New(cm.koanf.Delim())
-
-	// Load the source
-	if err := src.Load(context.Background(), tmpKoanf); err != nil {
+	// Load the source through config manager
+	if err := src.Load(context.Background(), cm); err != nil {
 		return fmt.Errorf("failed to load namespace %s: %w", namespace, err)
 	}
 
-	// Merge into main Koanf at the namespace path
-	if err := cm.koanf.MergeAt(tmpKoanf, namespace); err != nil {
-		return fmt.Errorf("failed to merge namespace %s: %w", namespace, err)
-	}
-
 	// Register the source for watching
-	if err := src.Watch(context.Background(), tmpKoanf, func(changedKeys []string, err error) {
+	if err := src.Watch(context.Background(), cm, func(changedKeys []string, err error) {
 		cm.handleConfigChanges(src, changedKeys)
 	}); err != nil {
 		cm.logger.Warn("failed to start namespace watcher",

--- a/manager_test.go
+++ b/manager_test.go
@@ -78,6 +78,36 @@ func TestNewConfigManager(t *testing.T) {
 	assert.Equal(t, "test_value", decoded)
 }
 
+func TestWithDelimiter(t *testing.T) {
+	// Create manager with custom delimiter
+	cm, err := NewConfigManager([]source.ConfigSource{}, WithDelimiter("/"))
+	require.NoError(t, err)
+
+	// Verify delimiter is set correctly
+	assert.Equal(t, "/", cm.Delim())
+
+	// Test setting and getting with custom delimiter
+	err = cm.Set(context.Background(), "test/key", "value")
+	assert.NoError(t, err)
+
+	val, _, err := cm.Get("test/key")
+	assert.NoError(t, err)
+	assert.Equal(t, "value", val)
+
+	// Verify nested keys work with custom delimiter
+	err = cm.Set(context.Background(), "test/nested/key", "nested_value")
+	assert.NoError(t, err)
+
+	nestedVal, _, err := cm.Get("test/nested/key")
+	assert.NoError(t, err)
+	assert.Equal(t, "nested_value", nestedVal)
+
+	// Verify keys are properly split
+	keys := cm.Keys()
+	assert.Contains(t, keys, "test/key")
+	assert.Contains(t, keys, "test/nested/key")
+}
+
 func TestConfigManager_WildcardSubscriptions(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -246,8 +276,11 @@ func TestConfigManager_SetGetExists(t *testing.T) {
 func TestConfigManager_All(t *testing.T) {
 	cm := newTestManager()
 
-	cm.Set(context.Background(), "test.string", "test_value")
-	cm.Set(context.Background(), "test.int", 123)
+	err := cm.Set(context.Background(), "test.string", "test_value")
+	require.NoError(t, err)
+
+	err = cm.Set(context.Background(), "test.int", 123)
+	require.NoError(t, err)
 
 	all := cm.All()
 	assert.Equal(t, map[string]any{
@@ -313,7 +346,8 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		err := cm.RegisterStruct("test.struct", &TestConfig{})
 		assert.NoError(t, err)
 
-		cm.Set(context.Background(), "test.struct.string_value", "pointer_reg")
+		err = cm.Set(context.Background(), "test.struct.string_value", "pointer_reg")
+		require.NoError(t, err)
 
 		var targetCfg TestConfig
 		raw, decoded, err := cm.Get("test.struct", &targetCfg)
@@ -473,8 +507,11 @@ func TestConfigManager_SetAtomic(t *testing.T) {
 	cm := newTestManager()
 
 	// Set initial values
-	cm.Set(context.Background(), "test.string", "initial_string")
-	cm.Set(context.Background(), "test.int", 123)
+	err := cm.Set(context.Background(), "test.string", "initial_string")
+	require.NoError(t, err)
+
+	err = cm.Set(context.Background(), "test.int", 123)
+	require.NoError(t, err)
 
 	// Define updates
 	updates := map[string]any{
@@ -483,7 +520,7 @@ func TestConfigManager_SetAtomic(t *testing.T) {
 	}
 
 	// Perform atomic update
-	err := cm.SetAtomic(context.Background(), updates)
+	err = cm.SetAtomic(context.Background(), updates)
 	assert.NoError(t, err)
 
 	// Verify values
@@ -504,9 +541,14 @@ func TestConfigManager_WithLogger(t *testing.T) {
 func TestConfigManager_getFilteredKeys(t *testing.T) {
 	cm := newTestManager()
 
-	cm.Set(context.Background(), "test.string", "test_value")
-	cm.Set(context.Background(), "test.int", 123)
-	cm.Set(context.Background(), "other.value", true)
+	err := cm.Set(context.Background(), "test.string", "test_value")
+	require.NoError(t, err)
+
+	err = cm.Set(context.Background(), "test.int", 123)
+	require.NoError(t, err)
+
+	err = cm.Set(context.Background(), "other.value", true)
+	require.NoError(t, err)
 
 	// No prefix
 	keys := cm.getFilteredKeys()
@@ -644,6 +686,44 @@ func TestConfigManager_implementsInterface(t *testing.T) {
 
 	validatorType := reflect.TypeOf((*Validator)(nil)).Elem()
 	assert.False(t, cm.implementsInterface("test", validatorType))
+}
+
+func TestConfigManager_DeleteNotifiesWatchers(t *testing.T) {
+	cm := newTestManagerWithData(map[string]any{
+		"test.key": "test_value",
+	})
+
+	// Track if callback was called
+	var callbackCalled bool
+	var callbackKey string
+	var callbackOldValue any
+	var callbackNewValue any
+
+	// Get the old value before setting up subscription
+	oldValue, _, _ := cm.Get("test.key")
+
+	// Subscribe to changes
+	unsub := cm.Subscribe("test.key", func(key string) {
+		callbackCalled = true
+		callbackKey = key
+		callbackOldValue = oldValue
+		callbackNewValue, _, _ = cm.Get("test.key") // Get current value after change
+	})
+	defer unsub()
+
+	// Delete the key
+	cm.Delete("test.key")
+
+	// Verify callback was called with correct values
+	assert.True(t, callbackCalled)
+	assert.Equal(t, "test.key", callbackKey)
+	assert.Equal(t, "test_value", callbackOldValue)
+	assert.Nil(t, callbackNewValue)
+
+	// Verify key was actually deleted
+	val, _, err := cm.Get("test.key")
+	assert.Error(t, err)
+	assert.Nil(t, val)
 }
 
 type mockSyncManager struct {
@@ -798,8 +878,11 @@ func TestConfigManager_RegisterAndLoadSource(t *testing.T) {
 
 	// Test watching by updating the source
 	updateChan := make(chan struct{})
+	var once sync.Once
 	cm.Subscribe("runtime.key", func(_ string) {
-		close(updateChan)
+		once.Do(func() {
+			close(updateChan)
+		})
 	})
 
 	memSource.Set("runtime.key", "updated_value")
@@ -813,7 +896,7 @@ func TestConfigManager_RegisterAndLoadSource(t *testing.T) {
 	}
 
 	// Test loading invalid source
-	invalidSource := &invalidSource{}
+	invalidSource := &source.TestingInvalidSource{}
 	err = cm.LoadSource(invalidSource, true, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load source")
@@ -821,11 +904,11 @@ func TestConfigManager_RegisterAndLoadSource(t *testing.T) {
 
 type invalidSource struct{}
 
-func (i *invalidSource) Load(ctx context.Context, k *koanf.Koanf) error {
+func (i *invalidSource) Load(ctx context.Context, cm Manager) error {
 	return fmt.Errorf("forced error")
 }
 
-func (i *invalidSource) Watch(ctx context.Context, k *koanf.Koanf, cb source.WatchOnChangeCallback) error {
+func (i *invalidSource) Watch(ctx context.Context, cm Manager, cb source.WatchOnChangeCallback) error {
 	return nil
 }
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,25 +1,16 @@
 package configmanager
 
 import (
-	"context"
-	"github.com/knadh/koanf/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.lumeweb.com/configmanager/source"
 )
 
-type mockSource struct{}
-
-func (m *mockSource) Load(ctx context.Context, k *koanf.Koanf) error { return nil }
-func (m *mockSource) Watch(ctx context.Context, k *koanf.Koanf, cb source.WatchOnChangeCallback) error {
-	return nil
-}
-
 func TestDefaultConfigRegistry(t *testing.T) {
 	t.Run("Register and GetSource", func(t *testing.T) {
 		reg := NewDefaultConfigRegistry()
-		src := &mockSource{}
+		src := source.NewMemoryConfigSource(nil)
 
 		reg.Register("test", src)
 		retrieved, ok := reg.GetSource("test")
@@ -36,7 +27,7 @@ func TestDefaultConfigRegistry(t *testing.T) {
 
 	t.Run("Unregister", func(t *testing.T) {
 		reg := NewDefaultConfigRegistry()
-		src := &mockSource{}
+		src := source.NewMemoryConfigSource(nil)
 
 		reg.Register("test", src)
 		reg.Unregister("test")
@@ -47,8 +38,8 @@ func TestDefaultConfigRegistry(t *testing.T) {
 
 	t.Run("ListNamespaces", func(t *testing.T) {
 		reg := NewDefaultConfigRegistry()
-		src1 := &mockSource{}
-		src2 := &mockSource{}
+		src1 := source.NewMemoryConfigSource(nil)
+		src2 := source.NewMemoryConfigSource(nil)
 
 		reg.Register("ns1", src1)
 		reg.Register("ns2", src2)
@@ -61,8 +52,8 @@ func TestDefaultConfigRegistry(t *testing.T) {
 
 	t.Run("FindMostSpecificNamespace", func(t *testing.T) {
 		reg := NewDefaultConfigRegistry()
-		src1 := &mockSource{}
-		src2 := &mockSource{}
+		src1 := source.NewMemoryConfigSource(nil)
+		src2 := source.NewMemoryConfigSource(nil)
 
 		reg.Register("parent", src1)
 		reg.Register("parent.child", src2)
@@ -100,7 +91,7 @@ func TestDefaultConfigRegistry(t *testing.T) {
 
 	t.Run("ConcurrentAccess", func(t *testing.T) {
 		reg := NewDefaultConfigRegistry()
-		src := &mockSource{}
+		src := source.NewMemoryConfigSource(nil)
 		done := make(chan bool)
 
 		go func() {

--- a/source/default.go
+++ b/source/default.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/knadh/koanf/maps"
-	"github.com/knadh/koanf/v2"
 	ireflect "go.lumeweb.com/configmanager/internal/reflect"
 	"reflect"
 )
@@ -45,23 +44,23 @@ func NewDefaultConfigSource(manager manager, defaults map[string]any) *DefaultCo
 	}
 }
 
-// flattenMap converts nested maps into dot notation keys using koanf's Flatten
+// flattenMap converts nested maps into keys using the manager's delimiter
 func flattenMap(m map[string]any, prefix string) map[string]any {
 	flattened, _ := maps.Flatten(m, nil, ".")
 	if prefix == "" {
 		return flattened
 	}
 
-	// Add prefix to all keys
+	// Add prefix to all keys using the manager's delimiter
 	prefixed := make(map[string]any, len(flattened))
 	for k, v := range flattened {
-		prefixed[prefix+"."+k] = v
+		prefixed[prefix+"."+k] = v // Still use dot here since maps.Flatten uses dots internally
 	}
 	return prefixed
 }
 
-// Load loads the default configuration values into the Koanf instance.
-func (d *DefaultConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
+// Load loads the default configuration values into the config manager.
+func (d *DefaultConfigSource) Load(ctx context.Context, cm configManager) error {
 	// First load defaults from registered structs that implement ConfigDefaults
 	for key, typ := range d.manager.GetRegisteredStructs() {
 		if ireflect.ImplementsConfigDefaults(typ) {
@@ -71,9 +70,10 @@ func (d *DefaultConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 			// Get defaults from the struct
 			if defaults, ok := instance.(ConfigDefaults); ok {
 				for defKey, defValue := range defaults.Defaults() {
-					fullKey := key + k.Delim() + defKey
-					if !k.Exists(fullKey) {
-						if err := k.Set(fullKey, defValue); err != nil {
+					fullKey := key + "." + defKey // Use dot since we're working with flattened map keys
+					// Only set if key doesn't exist
+					if exists, _, _ := cm.Get(fullKey); exists == nil {
+						if err := cm.Set(ctx, fullKey, defValue); err != nil {
 							return fmt.Errorf("failed to set default value for key %s: %w", fullKey, err)
 						}
 					}
@@ -84,9 +84,9 @@ func (d *DefaultConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 
 	// Then load static defaults
 	for key, value := range d.defaults {
-		// Only set the value if it doesn't already exist
-		if !k.Exists(key) {
-			if err := k.Set(key, value); err != nil {
+		// Only set if key doesn't exist
+		if exists, _, _ := cm.Get(key); exists == nil {
+			if err := cm.Set(ctx, key, value); err != nil {
 				return fmt.Errorf("failed to set default value for key %s: %w", key, err)
 			}
 		}
@@ -95,7 +95,7 @@ func (d *DefaultConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 }
 
 // Watch does not support watching default values, so it returns nil.
-func (d *DefaultConfigSource) Watch(ctx context.Context, k *koanf.Koanf, onChange WatchOnChangeCallback) error {
+func (d *DefaultConfigSource) Watch(ctx context.Context, cm configManager, onChange WatchOnChangeCallback) error {
 	// Default values cannot be watched, so return nil.
 	return nil
 }

--- a/source/default_test.go
+++ b/source/default_test.go
@@ -2,35 +2,156 @@ package source
 
 import (
 	"context"
-	"reflect"
-	"testing"
-
-	"github.com/knadh/koanf/v2"
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"reflect"
+	"slices"
+	"sync"
+	"testing"
 )
 
-// mockManager is a mock implementation of the manager interface needed by DefaultConfigSource
-type mockManager struct {
-	structs map[string]reflect.Type
+// isNumeric checks if a value is a numeric type
+func isNumeric(v any) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return true
+	}
+	return false
 }
 
-func newMockManager() *mockManager {
+// numericEqual compares two numeric values regardless of their concrete types
+func numericEqual(a, b any) bool {
+	return reflect.ValueOf(a).Convert(reflect.TypeOf(float64(0))).Float() ==
+		reflect.ValueOf(b).Convert(reflect.TypeOf(float64(0))).Float()
+}
+
+// mockManager is a mock implementation of configManager and manager interfaces
+type mockManager struct {
+	mu       sync.RWMutex
+	data     map[string]any
+	structs  map[string]reflect.Type
+	delim    string
+	setCalls []string // tracks Set calls for testing
+}
+
+func newMockManager(delim ...string) *mockManager {
+	d := "."
+	if len(delim) > 0 {
+		d = delim[0]
+	}
 	return &mockManager{
+		data:    make(map[string]any),
 		structs: make(map[string]reflect.Type),
+		delim:   d,
 	}
 }
 
+func (m *mockManager) All() map[string]any {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.data
+}
+
+// GetRegisteredStructs implements the manager interface
+func (m *mockManager) GetRegisteredStructs() map[string]reflect.Type {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.structs
+}
+
+// RegisterStruct implements the manager interface
 func (m *mockManager) RegisterStruct(key string, cfg any) error {
 	typ := reflect.TypeOf(cfg)
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.structs[key] = typ
 	return nil
 }
 
-func (m *mockManager) GetRegisteredStructs() map[string]reflect.Type {
-	return m.structs
+func (m *mockManager) Get(key string, target ...any) (any, any, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	val, exists := m.data[key]
+	if !exists {
+		return nil, nil, fmt.Errorf("key %s not found", key)
+	}
+	return val, val, nil
+}
+
+func (m *mockManager) Exists(key string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, exists := m.data[key]
+	return exists
+}
+
+func (m *mockManager) Set(ctx context.Context, key string, value any) error {
+	if ctx == nil {
+		return fmt.Errorf("context cannot be nil")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setCalls = append(m.setCalls, key)
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockManager) Delete(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.data, key)
+}
+
+func (m *mockManager) Keys() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	keys := make([]string, len(m.data))
+	i := 0
+	for k := range m.data {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func (m *mockManager) Delim() string {
+	return m.delim
+}
+
+// Additional test helper methods
+func (m *mockManager) assertSetCalled(t *testing.T, key string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !slices.Contains(m.setCalls, key) {
+		t.Errorf("expected Set(%q) to be called", key)
+	}
+}
+
+func (m *mockManager) assertValue(t *testing.T, key string, expected any) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	val, ok := m.data[key]
+	if !ok {
+		t.Errorf("key %q not found in manager", key)
+		return
+	}
+
+	// Handle numeric type differences using reflection
+	if isNumeric(expected) && isNumeric(val) {
+		if !numericEqual(expected, val) {
+			t.Errorf("for key %q, got %v (%T), want %v (%T)", key, val, val, expected, expected)
+		}
+		return
+	}
+
+	if !reflect.DeepEqual(val, expected) {
+		t.Errorf("for key %q, got %v (%T), want %v (%T)", key, val, val, expected, expected)
+	}
 }
 
 // testConfigWithDefaults implements ConfigDefaults
@@ -107,18 +228,17 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("load static defaults", func(t *testing.T) {
 		mgr := newMockManager()
-		k := koanf.New(".")
 		defaults := map[string]any{
 			"app.name": "TestApp",
 			"app.port": 8000,
 		}
 		dcs := NewDefaultConfigSource(mgr, defaults)
 
-		err := dcs.Load(ctx, k)
+		err := dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "TestApp", k.String("app.name"))
-		assert.Equal(t, 8000, k.Int("app.port"))
+		mgr.assertValue(t, "app.name", "TestApp")
+		mgr.assertValue(t, "app.port", 8000)
 	})
 
 	t.Run("load struct defaults", func(t *testing.T) {
@@ -126,14 +246,13 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("db", testConfigWithDefaults{})
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
 		dcs := NewDefaultConfigSource(mgr, nil)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "default_host", k.String("db.host"))
-		assert.Equal(t, 8080, k.Int("db.port"))
+		mgr.assertValue(t, "db.host", "default_host")
+		mgr.assertValue(t, "db.port", 8080)
 	})
 
 	t.Run("load struct without defaults", func(t *testing.T) {
@@ -141,13 +260,13 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("user", testConfigWithoutDefaults{})
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
 		dcs := NewDefaultConfigSource(mgr, nil)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.False(t, k.Exists("user.name"))
+		_, _, err = mgr.Get("user.name")
+		assert.Error(t, err)
 	})
 
 	t.Run("load struct with empty defaults", func(t *testing.T) {
@@ -155,20 +274,18 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("emptycfg", testConfigWithEmptyDefaults{})
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
 		dcs := NewDefaultConfigSource(mgr, nil)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.False(t, k.Exists("emptycfg.somekey")) // Ensure no keys are added
-		assert.Empty(t, k.All())
+		_, _, err = mgr.Get("emptycfg.somekey")
+		assert.Error(t, err)
 	})
 
 	t.Run("static defaults do not overwrite existing values", func(t *testing.T) {
 		mgr := newMockManager()
-		k := koanf.New(".")
-		err := k.Set("app.name", "ExistingApp")
+		err := mgr.Set(context.Background(), "app.name", "ExistingApp")
 		assert.NoError(t, err)
 
 		defaults := map[string]any{
@@ -176,10 +293,10 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		}
 		dcs := NewDefaultConfigSource(mgr, defaults)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "ExistingApp", k.String("app.name"))
+		mgr.assertValue(t, "app.name", "ExistingApp")
 	})
 
 	t.Run("struct defaults do not overwrite existing values", func(t *testing.T) {
@@ -187,17 +304,16 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("db", testConfigWithDefaults{})
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
-		err = k.Set("db.host", "existing_db_host")
+		err = mgr.Set(context.Background(), "db.host", "existing_db_host")
 		assert.NoError(t, err)
 
 		dcs := NewDefaultConfigSource(mgr, nil)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "existing_db_host", k.String("db.host"))
-		assert.Equal(t, 8080, k.Int("db.port")) // Port should still be default
+		mgr.assertValue(t, "db.host", "existing_db_host")
+		mgr.assertValue(t, "db.port", 8080) // Port should still be default
 	})
 
 	t.Run("load both static and struct defaults", func(t *testing.T) {
@@ -205,20 +321,19 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("db", testConfigWithDefaults{})
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
 		staticDefaults := map[string]any{
 			"app.name": "TestApp",
 		}
 		dcs := NewDefaultConfigSource(mgr, staticDefaults)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
 		// Check struct defaults
-		assert.Equal(t, "default_host", k.String("db.host"))
-		assert.Equal(t, 8080, k.Int("db.port"))
+		mgr.assertValue(t, "db.host", "default_host")
+		mgr.assertValue(t, "db.port", 8080)
 		// Check static defaults
-		assert.Equal(t, "TestApp", k.String("app.name"))
+		mgr.assertValue(t, "app.name", "TestApp")
 	})
 
 	t.Run("order of loading: struct defaults first, then static defaults", func(t *testing.T) {
@@ -226,19 +341,18 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("conflict", testConfigWithDefaults{}) // Defaults host to "default_host"
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
 		staticDefaults := map[string]any{
 			"conflict.host": "static_host_override", // Static default for the same key
 		}
 		dcs := NewDefaultConfigSource(mgr, staticDefaults)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
 		// Static defaults are loaded after struct defaults. If a key exists (e.g. from struct default),
 		// static default for the same key should NOT overwrite it.
-		assert.Equal(t, "default_host", k.String("conflict.host"))
-		assert.Equal(t, 8080, k.Int("conflict.port"))
+		mgr.assertValue(t, "conflict.host", "default_host")
+		mgr.assertValue(t, "conflict.port", 8080)
 	})
 
 	t.Run("static defaults for a key not in struct defaults", func(t *testing.T) {
@@ -246,18 +360,17 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 		err := mgr.RegisterStruct("db", testConfigWithDefaults{}) // Defaults host and port
 		assert.NoError(t, err)
 
-		k := koanf.New(".")
 		staticDefaults := map[string]any{
 			"db.user": "static_user", // Static default for a key not in struct defaults
 		}
 		dcs := NewDefaultConfigSource(mgr, staticDefaults)
 
-		err = dcs.Load(ctx, k)
+		err = dcs.Load(ctx, mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "default_host", k.String("db.host"))
-		assert.Equal(t, 8080, k.Int("db.port"))
-		assert.Equal(t, "static_user", k.String("db.user"))
+		mgr.assertValue(t, "db.host", "default_host")
+		mgr.assertValue(t, "db.port", 8080)
+		mgr.assertValue(t, "db.user", "static_user")
 	})
 
 }
@@ -265,10 +378,9 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 func TestDefaultConfigSource_Watch(t *testing.T) {
 	mgr := newMockManager()
 	dcs := NewDefaultConfigSource(mgr, nil)
-	k := koanf.New(".")
 	ctx := context.Background()
 
-	err := dcs.Watch(ctx, k, func(changedKeys []string, err error) {
+	err := dcs.Watch(ctx, mgr, func(changedKeys []string, err error) {
 		assert.Fail(t, "Watch callback should not be called for DefaultConfigSource")
 	})
 	assert.NoError(t, err, "Watch should return nil and be a no-op")

--- a/source/env.go
+++ b/source/env.go
@@ -25,11 +25,14 @@ func NewEnvConfigSource(prefix, delimiter string) *EnvConfigSource {
 	}
 }
 
-// Load loads the configuration from environment variables into the Koanf instance.
-func (e *EnvConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
-	if k == nil {
-		return fmt.Errorf("koanf instance cannot be nil")
+// Load loads the configuration from environment variables into the config manager.
+func (e *EnvConfigSource) Load(ctx context.Context, cm configManager) error {
+	if cm == nil {
+		return fmt.Errorf("config manager cannot be nil")
 	}
+
+	// Create temporary koanf to load env vars
+	tmpKoanf := koanf.New(cm.Delim())
 
 	// Create a callback that transforms env var names to config keys
 	cb := func(s string) string {
@@ -41,19 +44,30 @@ func (e *EnvConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 		// Convert to lowercase and replace delimiter with koanf's delimiter
 		s = strings.ToLower(s)
 		if e.delimiter != "" {
-			s = strings.ReplaceAll(s, e.delimiter, k.Delim())
+			s = strings.ReplaceAll(s, e.delimiter, tmpKoanf.Delim())
 		}
 		return s
 	}
 
 	// Use the env provider with our callback
-	provider := env.Provider(e.prefix, k.Delim(), cb)
-	return k.Load(provider, nil)
+	provider := env.Provider(e.prefix, tmpKoanf.Delim(), cb)
+	if err := tmpKoanf.Load(provider, nil); err != nil {
+		return err
+	}
+
+	// Set values through config manager to trigger validation
+	for key, value := range tmpKoanf.All() {
+		if err := cm.Set(ctx, key, value); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Watch watches for changes in the environment variables and triggers the onChange function when a change occurs.
 // Environment variables cannot be watched in a cross-platform way, so this is a no-op.
-func (e *EnvConfigSource) Watch(_ context.Context, _ *koanf.Koanf, _ WatchOnChangeCallback) error {
+func (e *EnvConfigSource) Watch(_ context.Context, _ configManager, _ WatchOnChangeCallback) error {
 	// Environment variables cannot be watched in a cross-platform way
 	return nil
 }

--- a/source/env_test.go
+++ b/source/env_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/knadh/koanf/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -119,15 +118,17 @@ func TestEnvConfigSource_Load(t *testing.T) {
 			setup(tt.envVars)
 			defer cleanup(tt.envVars)
 
-			k := koanf.New(tt.koanfDelim)
+			mgr := newMockManager(tt.koanfDelim)
 			source := NewEnvConfigSource(tt.prefix, tt.delimiter)
 
-			err := source.Load(ctx, k)
+			err := source.Load(ctx, mgr)
 			assert.NoError(t, err)
 
-			// Only check the keys we expect - ignore other env vars
-			for key, val := range tt.expected {
-				assert.Equal(t, val, k.Get(key), "Value for key '%s' should match", key)
+			// Verify values were set in the mock manager
+			for key, expectedVal := range tt.expected {
+				val, _, err := mgr.Get(key)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedVal, val, "Value for key '%s' should match", key)
 			}
 		})
 	}
@@ -135,12 +136,12 @@ func TestEnvConfigSource_Load(t *testing.T) {
 
 func TestEnvConfigSource_Watch(t *testing.T) {
 	ctx := context.Background()
-	k := koanf.New(".")
+	mgr := newMockManager()
 	source := NewEnvConfigSource("TEST_", "_")
 
 	// Watch should be a no-op and not call the callback
 	// It should also return nil error
-	err := source.Watch(ctx, k, func(changedKeys []string, err error) {
+	err := source.Watch(ctx, mgr, func(changedKeys []string, err error) {
 		assert.Fail(t, "Watch callback should not be called for EnvConfigSource")
 	})
 	assert.NoError(t, err, "Watch should return nil and be a no-op")

--- a/source/etcd.go
+++ b/source/etcd.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/knadh/koanf/v2"
+	"github.com/knadh/koanf/maps"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	_ "go.etcd.io/etcd/client/v3/mock/mockserver"
 	config "go.lumeweb.com/configmanager/config"
@@ -42,12 +42,12 @@ type EtcdConfigSource struct {
 }
 
 // Persist writes configuration changes back to etcd.
-func (e *EtcdConfigSource) Persist(ctx context.Context, k *koanf.Koanf, keyPrefix ...string) error {
+func (e *EtcdConfigSource) Persist(ctx context.Context, cm configManager, keyPrefix ...string) error {
 	e.logger.Debug("Persisting configuration to etcd",
 		zap.Strings("keyPrefix", keyPrefix))
 
 	// If no keys specified, persist everything
-	keys := k.Keys()
+	keys := cm.Keys()
 	if len(keyPrefix) > 0 {
 		keys = keyPrefix
 		e.logger.Debug("Persisting prefixed keys",
@@ -58,10 +58,11 @@ func (e *EtcdConfigSource) Persist(ctx context.Context, k *koanf.Koanf, keyPrefi
 	}
 
 	for _, key := range keys {
-		value := k.Get(key)
-		if value == nil {
-			e.logger.Debug("Skipping nil value",
-				zap.String("key", key))
+		value, _, err := cm.Get(key)
+		if err != nil {
+			e.logger.Debug("Skipping non-existent key",
+				zap.String("key", key),
+				zap.Error(err))
 			continue
 		}
 
@@ -118,8 +119,8 @@ func NewEtcdConfigSource(config *config.EtcdConfig, opts ...EtcdConfigSourceOpti
 	return e, nil
 }
 
-// Load loads the configuration from etcd into the Koanf instance.
-func (e *EtcdConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
+// Load loads the configuration from etcd into the config manager.
+func (e *EtcdConfigSource) Load(ctx context.Context, cm configManager) error {
 	e.logger.Debug("Loading configuration from etcd",
 		zap.String("prefix", e.prefix))
 
@@ -134,19 +135,10 @@ func (e *EtcdConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 	e.logger.Debug("Retrieved keys from etcd",
 		zap.Int("count", len(resp.Kvs)))
 
-	// Log all retrieved keys/values for debugging
-	for _, kv := range resp.Kvs {
-		e.logger.Debug("Retrieved etcd key-value",
-			zap.String("key", string(kv.Key)),
-			zap.ByteString("value", kv.Value),
-			zap.Int64("version", kv.Version))
-	}
-
-	configMap := make(map[string]any)
 	for _, kv := range resp.Kvs {
 		key := strings.TrimPrefix(string(kv.Key), e.prefix)
 		key = strings.TrimPrefix(key, "/")
-		key = strings.ReplaceAll(key, "/", k.Delim())
+		key = strings.ReplaceAll(key, "/", cm.Delim())
 
 		e.logger.Debug("Processing etcd key",
 			zap.String("raw_key", string(kv.Key)),
@@ -161,29 +153,38 @@ func (e *EtcdConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 			continue
 		}
 
-		configMap[key] = value
-		e.logger.Debug("Added config value",
-			zap.String("key", key),
-			zap.Any("value", value))
+		// Flatten nested maps using koanf/maps
+		if nestedMap, ok := value.(map[string]interface{}); ok {
+			flattenedMap, _ := maps.Flatten(nestedMap, nil, cm.Delim())
+			for flatKey, flatValue := range flattenedMap {
+				fullKey := joinKeys(key, flatKey, cm.Delim())
+				if err := cm.Set(ctx, fullKey, flatValue); err != nil {
+					e.logger.Error("Failed to set config value",
+						zap.String("key", fullKey),
+						zap.Error(err))
+					return fmt.Errorf("failed to set config value for key %s: %w", fullKey, err)
+				}
+			}
+		} else {
+			e.logger.Debug("Setting config value",
+				zap.String("key", key),
+				zap.Any("value", value))
+
+			if err := cm.Set(ctx, key, value); err != nil {
+				e.logger.Error("Failed to set config value",
+					zap.String("key", key),
+					zap.Error(err))
+				return fmt.Errorf("failed to set config value for key %s: %w", key, err)
+			}
+		}
 	}
 
-	e.logger.Debug("Final config map before loading into koanf",
-		zap.Any("config_map", configMap))
-
-	err = k.Load(newEtcdMapProvider(configMap), nil)
-	if err != nil {
-		e.logger.Error("Failed to load config map into koanf",
-			zap.Error(err))
-		return err
-	}
-
-	e.logger.Debug("Successfully loaded config from etcd",
-		zap.Strings("keys", k.Keys()))
+	e.logger.Debug("Successfully loaded config from etcd")
 	return nil
 }
 
 // Watch watches for changes in etcd and triggers the onChange function when a change occurs.
-func (e *EtcdConfigSource) Watch(ctx context.Context, k *koanf.Koanf, onChange WatchOnChangeCallback) error {
+func (e *EtcdConfigSource) Watch(ctx context.Context, cm configManager, onChange WatchOnChangeCallback) error {
 	e.watchMu.Lock()
 	defer e.watchMu.Unlock()
 
@@ -218,7 +219,7 @@ func (e *EtcdConfigSource) Watch(ctx context.Context, k *koanf.Koanf, onChange W
 					zap.Strings("changed_keys", changedKeys))
 
 				// Reload the config when changes are detected
-				if err := e.Load(ctx, k); err != nil {
+				if err := e.Load(ctx, cm); err != nil {
 					e.logger.Error("Failed to reload config from etcd",
 						zap.Error(err))
 					continue
@@ -248,25 +249,19 @@ func (e *EtcdConfigSource) Stop() error {
 
 // fullKey combines the etcd prefix with the configuration key
 func (e *EtcdConfigSource) fullKey(key string) string {
-	if e.prefix == "" {
+	return joinKeys(e.prefix, key, "/")
+}
+
+// joinKeys safely joins two keys with a delimiter, handling empty parts
+func joinKeys(prefix, key, delim string) string {
+	if prefix == "" {
 		return key
 	}
-	return e.prefix + "/" + key
-}
-
-// etcdMapProvider implements koanf.Provider for a map[string]any specifically for etcd
-type etcdMapProvider struct {
-	data map[string]any
-}
-
-func newEtcdMapProvider(data map[string]any) *etcdMapProvider {
-	return &etcdMapProvider{data: data}
-}
-
-func (m *etcdMapProvider) Read() (map[string]any, error) {
-	return m.data, nil
-}
-
-func (m *etcdMapProvider) ReadBytes() ([]byte, error) {
-	return nil, fmt.Errorf("etcdMapProvider does not support reading bytes")
+	if key == "" {
+		return prefix
+	}
+	// Trim any existing delimiters from ends
+	prefix = strings.TrimSuffix(prefix, delim)
+	key = strings.TrimPrefix(key, delim)
+	return prefix + delim + key
 }

--- a/source/etcd_test.go
+++ b/source/etcd_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knadh/koanf/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/configmanager/config"
@@ -21,11 +20,14 @@ type etcdTestFixture struct {
 	mockWatcher *etcd.MockWatcher
 	etcdManager etcd.EtcdManager
 	source      *EtcdConfigSource
+	mgr         *mockManager
 }
 
 func setupEtcdTest(t *testing.T, initialData map[string]string) *etcdTestFixture {
 	ctx := context.Background()
 	logger := zap.NewNop()
+
+	mgr := newMockManager()
 
 	// Create mock etcd client
 	mockClient := etcd.NewMockEtcdClient([]string{"mock"})
@@ -68,6 +70,7 @@ func setupEtcdTest(t *testing.T, initialData map[string]string) *etcdTestFixture
 		mockWatcher: etcdManager.Watcher().(*etcd.MockWatcher),
 		etcdManager: etcdManager,
 		source:      source,
+		mgr:         mgr,
 	}
 }
 
@@ -79,24 +82,24 @@ func TestEtcdConfigSource(t *testing.T) {
 			"config/nested": `{"subkey":"subvalue"}`,
 		})
 
-		k := koanf.New(".")
-		err := f.source.Load(f.ctx, k)
+		mgr := newMockManager()
+		err := f.source.Load(f.ctx, mgr)
 		require.NoError(t, err)
 
 		// Verify loaded values
-		assert.Equal(t, "value1", k.String("key1"))
-		assert.Equal(t, 42, k.Int("key2"))
-		assert.Equal(t, "subvalue", k.String("nested.subkey"))
+		mgr.assertValue(t, "key1", "value1")
+		mgr.assertValue(t, "key2", 42)
+		mgr.assertValue(t, "nested.subkey", "subvalue")
 	})
 
 	t.Run("Watch", func(t *testing.T) {
 		f := setupEtcdTest(t, nil) // No initial data needed for this test
 
-		k := koanf.New(".")
+		mgr := newMockManager()
 		changeChan := make(chan []string, 1)
 
 		// Start watching
-		err := f.source.Watch(f.ctx, k, func(changedKeys []string, err error) {
+		err := f.source.Watch(f.ctx, mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -112,7 +115,9 @@ func TestEtcdConfigSource(t *testing.T) {
 		select {
 		case changedKeys := <-changeChan:
 			assert.Equal(t, []string{"changed"}, changedKeys)
-			assert.Equal(t, "newvalue", k.String("changed.newkey"))
+			val, _, err := mgr.Get("changed.newkey")
+			require.NoError(t, err)
+			assert.Equal(t, "newvalue", val)
 
 		case <-time.After(1 * time.Second):
 			t.Fatal("timeout waiting for watch notification")
@@ -122,11 +127,10 @@ func TestEtcdConfigSource(t *testing.T) {
 	t.Run("Persist", func(t *testing.T) {
 		f := setupEtcdTest(t, nil) // No initial data needed for this test
 
-		k := koanf.New(".")
-		err := k.Set("key.to.persist", "persisted-value")
+		err := f.mgr.Set(f.ctx, "key.to.persist", "persisted-value")
 		require.NoError(t, err)
 
-		err = f.source.Persist(f.ctx, k, "key.to.persist")
+		err = f.source.Persist(f.ctx, f.mgr, "key.to.persist")
 		require.NoError(t, err)
 
 		// Verify value was persisted to etcd

--- a/source/file.go
+++ b/source/file.go
@@ -28,15 +28,25 @@ func NewFileConfigSource(path string) (*FileConfigSource, error) {
 	}, nil
 }
 
-// Load loads the configuration from the file into the Koanf instance.
-func (f *FileConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
-	// Use the file provider's Read() method which handles all the file operations
-	// including existence checks, reading, and parsing based on file extension
-	return k.Load(f.provider, nil)
+// Load loads the configuration from the file into the config manager.
+func (f *FileConfigSource) Load(ctx context.Context, cm configManager) error {
+	// Create temporary koanf to load file
+	tmpKoanf := koanf.New(".")
+	if err := tmpKoanf.Load(f.provider, nil); err != nil {
+		return err
+	}
+
+	// Set values through config manager to trigger validation
+	for key, value := range tmpKoanf.All() {
+		if err := cm.Set(ctx, key, value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Watch watches for changes in the file and triggers the onChange function when a change occurs.
-func (f *FileConfigSource) Watch(ctx context.Context, k *koanf.Koanf, onChange WatchOnChangeCallback) error {
+func (f *FileConfigSource) Watch(ctx context.Context, cm configManager, onChange WatchOnChangeCallback) error {
 	// Use the file provider's built-in Watch() functionality
 	return f.provider.Watch(func(event any, err error) {
 		if err != nil {
@@ -46,7 +56,7 @@ func (f *FileConfigSource) Watch(ctx context.Context, k *koanf.Koanf, onChange W
 		}
 
 		// Reload the config file on changes
-		if err := f.Load(ctx, k); err != nil {
+		if err := f.Load(ctx, cm); err != nil {
 			// Pass through the load error with WatchAllChanges to indicate
 			// the configuration may be in an inconsistent state
 			onChange([]string{WatchAllChanges}, fmt.Errorf("failed to reload config file: %w", err))

--- a/source/file_test.go
+++ b/source/file_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knadh/koanf/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,11 +20,11 @@ func TestFileSourceWrapper_Load(t *testing.T) {
 		}()
 
 		f := NewFileSource(tmpFile).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
-		assert.Equal(t, "test_value", k.String("test.key"))
+		mgr.assertValue(t, "test.key", "test_value")
 	})
 
 	t.Run("load empty file", func(t *testing.T) {
@@ -37,18 +36,18 @@ func TestFileSourceWrapper_Load(t *testing.T) {
 		}()
 
 		f := NewFileSource(tmpFile).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
-		assert.Empty(t, k.Keys())
+		assert.Empty(t, mgr.Keys())
 	})
 
 	t.Run("load non-existent file", func(t *testing.T) {
 		f := NewFileSource("nonexistent.yaml").(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.Error(t, err)
 	})
 }
@@ -67,13 +66,13 @@ test.key3: initial
 		}()
 
 		f := NewFileSource(tmpFile).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -90,9 +89,15 @@ test.key3: initial
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, []string{"test.key"}, keys)
-			assert.Equal(t, "updated", k.String("test.key"))
-			assert.Equal(t, "initial", k.String("test.key2"))
-			assert.Equal(t, "initial", k.String("test.key3"))
+			val1, _, err1 := mgr.Get("test.key")
+			val2, _, err2 := mgr.Get("test.key2")
+			val3, _, err3 := mgr.Get("test.key3")
+			require.NoError(t, err1)
+			require.NoError(t, err2)
+			require.NoError(t, err3)
+			assert.Equal(t, "updated", val1)
+			assert.Equal(t, "initial", val2)
+			assert.Equal(t, "initial", val3)
 		case <-time.After(2 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
@@ -108,13 +113,13 @@ test.key3: initial
 		}()
 
 		f := NewFileSource(tmpFile).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -146,13 +151,13 @@ key4: v4
 		}()
 
 		f := NewFileSource(tmpFile, WithChangedThreshold(0.5)).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -189,13 +194,13 @@ key4: v4
 		}()
 
 		f := NewFileSource(tmpFile, WithChangedThreshold(0.5)).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -226,13 +231,13 @@ key4: v4
 		}(tmpFile)
 
 		f := NewFileSource(tmpFile, WithChangedThreshold(1)).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -265,13 +270,13 @@ key2: v2
 		}()
 
 		f := NewFileSource(tmpFile, WithChangedThreshold(1)).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -298,13 +303,13 @@ key2: v2
 		}()
 
 		f := NewFileSource(tmpFile, WithChangedThreshold(0.5)).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)
@@ -334,13 +339,13 @@ key2: v2
 		}()
 
 		f := NewFileSource(tmpFile, WithChangedThreshold(0.5)).(*fileSourceWrapper)
-		k := koanf.New(".")
+		mgr := newMockManager()
 
-		err := f.Load(context.Background(), k)
+		err := f.Load(context.Background(), mgr)
 		require.NoError(t, err)
 
 		changeChan := make(chan []string, 1)
-		err = f.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err = f.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		require.NoError(t, err)

--- a/source/file_wrapper.go
+++ b/source/file_wrapper.go
@@ -50,7 +50,7 @@ func WithFileSourceLogger(logger *zap.Logger) FileSourceOption {
 	}
 }
 
-func (f *fileSourceWrapper) Load(ctx context.Context, k *koanf.Koanf) error {
+func (f *fileSourceWrapper) Load(ctx context.Context, cm configManager) error {
 	f.prevLock.Lock()
 	defer f.prevLock.Unlock()
 
@@ -59,16 +59,21 @@ func (f *fileSourceWrapper) Load(ctx context.Context, k *koanf.Koanf) error {
 		f.prevState = make(map[string]any)
 	}
 
-	// Clear existing values before loading new ones
-	k.Delete("")
-
-	// Load new configuration
-	if err := k.Load(f.provider, yaml.Parser()); err != nil {
+	// Create temporary koanf to load file
+	tmpKoanf := koanf.New(".")
+	if err := tmpKoanf.Load(f.provider, yaml.Parser()); err != nil {
 		return err
 	}
 
 	// Store the new state
-	newState := k.All()
+	newState := tmpKoanf.All()
+
+	// Set values through config manager to trigger validation
+	for key, value := range newState {
+		if err := cm.Set(ctx, key, value); err != nil {
+			return err
+		}
+	}
 
 	// Compare with previous state if this isn't the first load
 	if f.initialLoad {
@@ -90,7 +95,7 @@ func (f *fileSourceWrapper) Load(ctx context.Context, k *koanf.Koanf) error {
 	return nil
 }
 
-func (f *fileSourceWrapper) Watch(ctx context.Context, k *koanf.Koanf, cb WatchOnChangeCallback) error {
+func (f *fileSourceWrapper) Watch(ctx context.Context, cm configManager, cb WatchOnChangeCallback) error {
 	return f.provider.Watch(func(event any, err error) {
 		if err != nil {
 			// if err is not nil, it means the file was removed
@@ -118,15 +123,20 @@ func (f *fileSourceWrapper) Watch(ctx context.Context, k *koanf.Koanf, cb WatchO
 			return
 		}
 
+		// Update config manager with changed values
 		for _, key := range changedKeys {
-			if !tmpKoanf.Exists(key) {
-				k.Delete(key)
+			if tmpKoanf.Exists(key) {
+				if err := cm.Set(ctx, key, tmpKoanf.Get(key)); err != nil {
+					cb(nil, err)
+					return
+				}
+			} else {
+				// Handle deleted keys by setting nil
+				if err := cm.Set(ctx, key, nil); err != nil {
+					cb(nil, err)
+					return
+				}
 			}
-		}
-
-		if err := k.Load(f.provider, yaml.Parser()); err != nil {
-			cb(nil, err)
-			return
 		}
 
 		cb(changedKeys, nil)

--- a/source/invalid.go
+++ b/source/invalid.go
@@ -1,0 +1,38 @@
+package source
+
+import (
+	"context"
+	"fmt"
+)
+
+// TestingInvalidSource is a ConfigSource that always returns errors.
+// Useful for testing error handling.
+type TestingInvalidSource struct {
+	loadError  string
+	watchError string
+}
+
+// New creates a new TestingInvalidSource with custom error messages.
+// If empty strings are provided, default error messages will be used.
+func New(loadError, watchError string) *TestingInvalidSource {
+	if loadError == "" {
+		loadError = "invalid source: forced load error"
+	}
+	if watchError == "" {
+		watchError = "invalid source: forced watch error"
+	}
+	return &TestingInvalidSource{
+		loadError:  loadError,
+		watchError: watchError,
+	}
+}
+
+// Load always returns an error.
+func (i *TestingInvalidSource) Load(ctx context.Context, cm configManager) error {
+	return fmt.Errorf("%s", i.loadError)
+}
+
+// Watch always returns an error.
+func (i *TestingInvalidSource) Watch(ctx context.Context, cm configManager, cb WatchOnChangeCallback) error {
+	return fmt.Errorf("%s", i.watchError)
+}

--- a/source/invalid_test.go
+++ b/source/invalid_test.go
@@ -1,0 +1,32 @@
+package source
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidSource(t *testing.T) {
+	t.Run("default errors", func(t *testing.T) {
+		src := New("", "")
+		mgr := &mockManager{}
+
+		err := src.Load(context.Background(), mgr)
+		assert.EqualError(t, err, "invalid source: forced load error")
+
+		err = src.Watch(context.Background(), mgr, func([]string, error) {})
+		assert.EqualError(t, err, "invalid source: forced watch error")
+	})
+
+	t.Run("custom errors", func(t *testing.T) {
+		src := New("custom load error", "custom watch error")
+		mgr := &mockManager{}
+
+		err := src.Load(context.Background(), mgr)
+		assert.EqualError(t, err, "custom load error")
+
+		err = src.Watch(context.Background(), mgr, func([]string, error) {})
+		assert.EqualError(t, err, "custom watch error")
+	})
+}

--- a/source/memory.go
+++ b/source/memory.go
@@ -2,10 +2,10 @@ package source
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"go.uber.org/zap"
 	"sync"
-
-	"github.com/knadh/koanf/v2"
 )
 
 // MemoryConfigSource is an in-memory configuration source that can be used for testing
@@ -47,13 +47,13 @@ func WithMemorySourceLogger(logger *zap.Logger) MemoryConfigSourceOption {
 	}
 }
 
-// Load loads the in-memory configuration into the Koanf instance.
-func (m *MemoryConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
+// Load loads the in-memory configuration into the config manager.
+func (m *MemoryConfigSource) Load(ctx context.Context, cm configManager) error {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
 	for key, value := range m.data {
-		if err := k.Set(key, value); err != nil {
+		if err := cm.Set(ctx, key, value); err != nil {
 			return err
 		}
 	}
@@ -61,7 +61,7 @@ func (m *MemoryConfigSource) Load(ctx context.Context, k *koanf.Koanf) error {
 }
 
 // Watch registers a callback to be notified when changes occur.
-func (m *MemoryConfigSource) Watch(ctx context.Context, k *koanf.Koanf, cb WatchOnChangeCallback) error {
+func (m *MemoryConfigSource) Watch(ctx context.Context, cm configManager, cb WatchOnChangeCallback) error {
 	m.watchLock.Lock()
 	defer m.watchLock.Unlock()
 
@@ -70,14 +70,22 @@ func (m *MemoryConfigSource) Watch(ctx context.Context, k *koanf.Koanf, cb Watch
 		m.mutex.RLock()
 		if len(m.data) == 0 {
 			// Source was cleared - clear all keys from koanf
-			allKeys := k.Keys()
+			allKeys := cm.Keys()
+			var deleteErrs []error
 			for _, key := range allKeys {
-				k.Delete(key)
+				cm.Delete(key)
+				// Check if deletion failed (though Delete() doesn't return error)
+				if cm.Exists(key) {
+					deleteErrs = append(deleteErrs, fmt.Errorf("failed to delete key %s", key))
+				}
+			}
+			if len(deleteErrs) > 0 {
+				err = fmt.Errorf("failed to clear all keys: %w", errors.Join(deleteErrs...))
 			}
 		} else {
 			// Update koanf with current values
 			for key, value := range m.data {
-				if err := k.Set(key, value); err != nil {
+				if err := cm.Set(ctx, key, value); err != nil {
 					m.logger.Error("failed to update koanf value",
 						zap.String("key", key),
 						zap.Error(err))
@@ -126,6 +134,24 @@ func (m *MemoryConfigSource) Delete(key string) {
 	}
 }
 
+// DeleteFromManager deletes a key from the passed config manager and notifies watchers.
+func (m *MemoryConfigSource) DeleteFromManager(key string, cm configManager) {
+	m.mutex.Lock()
+	delete(m.data, key)
+	m.mutex.Unlock()
+
+	cm.Delete(key)
+
+	m.watchLock.Lock()
+	watchers := make([]WatchOnChangeCallback, len(m.watchers))
+	copy(watchers, m.watchers)
+	m.watchLock.Unlock()
+
+	for _, cb := range watchers {
+		cb([]string{key}, nil)
+	}
+}
+
 // Clear removes all data from the memory source.
 func (m *MemoryConfigSource) Clear() {
 	m.mutex.Lock()
@@ -147,7 +173,7 @@ func (m *MemoryConfigSource) Clear() {
 }
 
 // Persist implements PersistableConfigSource but does nothing since memory is ephemeral.
-func (m *MemoryConfigSource) Persist(ctx context.Context, k *koanf.Koanf, keyPrefix ...string) error {
+func (m *MemoryConfigSource) Persist(ctx context.Context, cm configManager, keyPrefix ...string) error {
 	// Memory source doesn't persist changes
 	return nil
 }

--- a/source/memory_test.go
+++ b/source/memory_test.go
@@ -2,10 +2,10 @@ package source
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
-	"github.com/knadh/koanf/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,47 +19,51 @@ func TestMemoryConfigSource(t *testing.T) {
 	src := NewMemoryConfigSource(initialData)
 
 	t.Run("Load initial data", func(t *testing.T) {
-		k := koanf.New(".")
-		err := src.Load(context.Background(), k)
+		mgr := newMockManager()
+		err := src.Load(context.Background(), mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "value", k.Get("test.key"))
-		assert.Equal(t, 42, k.Get("test.num"))
-		assert.Equal(t, true, k.Get("test.bool"))
+		mgr.assertValue(t, "test.key", "value")
+		mgr.assertValue(t, "test.num", 42)
+		mgr.assertValue(t, "test.bool", true)
 	})
 
 	t.Run("Set and Load new data", func(t *testing.T) {
 		src.Set("new.key", "new value")
-		k := koanf.New(".")
-		err := src.Load(context.Background(), k)
+		mgr := newMockManager()
+		err := src.Load(context.Background(), mgr)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "new value", k.Get("new.key"))
+		val, _, err := mgr.Get("new.key")
+		require.NoError(t, err)
+		assert.Equal(t, "new value", val)
 	})
 
 	t.Run("Delete key", func(t *testing.T) {
 		src.Delete("test.key")
-		k := koanf.New(".")
-		err := src.Load(context.Background(), k)
+		mgr := newMockManager()
+		err := src.Load(context.Background(), mgr)
 		assert.NoError(t, err)
 
-		assert.Nil(t, k.Get("test.key"))
+		val, _, err := mgr.Get("test.key")
+		require.Error(t, err)
+		assert.Nil(t, val)
 	})
 
 	t.Run("Clear all data", func(t *testing.T) {
 		src.Clear()
-		k := koanf.New(".")
-		err := src.Load(context.Background(), k)
+		mgr := newMockManager()
+		err := src.Load(context.Background(), mgr)
 		assert.NoError(t, err)
 
-		assert.Empty(t, k.All())
+		assert.Empty(t, mgr.All())
 	})
 
 	t.Run("Watch notifications", func(t *testing.T) {
-		k := koanf.New(".")
+		mgr := newMockManager()
 		changeChan := make(chan []string, 5) // Buffer for multiple notifications
 
-		err := src.Watch(context.Background(), k, func(changedKeys []string, err error) {
+		err := src.Watch(context.Background(), mgr, func(changedKeys []string, err error) {
 			changeChan <- changedKeys
 		})
 		assert.NoError(t, err)
@@ -71,7 +75,9 @@ func TestMemoryConfigSource(t *testing.T) {
 		select {
 		case changedKeys := <-changeChan:
 			assert.Equal(t, []string{"watch.test"}, changedKeys)
-			assert.Equal(t, "value", k.Get("watch.test"))
+			val, _, err := mgr.Get("watch.test")
+			require.NoError(t, err)
+			assert.Equal(t, "value", val)
 		case <-time.After(100 * time.Millisecond):
 			t.Fatal("timeout waiting for first watch notification")
 		}
@@ -97,25 +103,27 @@ func TestMemoryConfigSource(t *testing.T) {
 		}
 
 		// Test delete notification
-		src.Delete("watch.test2")
-		
+		src.DeleteFromManager("watch.test2", mgr)
+
 		// Wait for fourth notification
 		select {
 		case changedKeys := <-changeChan:
 			assert.Equal(t, []string{"watch.test2"}, changedKeys)
-			assert.Equal(t, 42, k.Get("watch.test2"))
+			val, _, err := mgr.Get("watch.test2")
+			require.Error(t, err)
+			assert.Nil(t, val)
 		case <-time.After(100 * time.Millisecond):
 			t.Fatal("timeout waiting for delete watch notification")
 		}
 
 		// Test clear notification
 		src.Clear()
-		
+
 		// Wait for fifth notification
 		select {
 		case changedKeys := <-changeChan:
 			assert.ElementsMatch(t, []string{"watch.test", "watch.test3"}, changedKeys)
-			assert.Equal(t, map[string]any{}, k.All())
+			assert.Equal(t, map[string]any{}, mgr.All())
 		case <-time.After(100 * time.Millisecond):
 			t.Fatal("timeout waiting for clear watch notification")
 		}
@@ -125,7 +133,8 @@ func TestMemoryConfigSource(t *testing.T) {
 	})
 
 	t.Run("Persist does nothing", func(t *testing.T) {
-		err := src.Persist(context.Background(), koanf.New("."))
+		mgr := newMockManager()
+		err := src.Persist(context.Background(), mgr)
 		assert.NoError(t, err)
 	})
 }

--- a/source/source.go
+++ b/source/source.go
@@ -3,17 +3,15 @@ package source
 import (
 	"context"
 	"fmt"
-
-	"github.com/knadh/koanf/v2"
 )
 
 // ConfigSource abstracts the loading of configuration data from different sources.
 type ConfigSource interface {
-	// Load loads configuration data from a specific source into the Koanf instance.
-	Load(ctx context.Context, k *koanf.Koanf) error
+	// Load loads configuration data from a specific source into the config manager.
+	Load(ctx context.Context, cm configManager) error
 	// Watch watches for changes in the configuration source and triggers the onChange function with the keys that changed.
 	// If the source does not support watching, this method should return nil.
-	Watch(ctx context.Context, k *koanf.Koanf, onChange WatchOnChangeCallback) error
+	Watch(ctx context.Context, cm configManager, onChange WatchOnChangeCallback) error
 }
 
 // WatchAllChanges is a special value that indicates all configuration values may have changed.
@@ -54,5 +52,14 @@ func FindSourceByType[T ConfigSource](sources []ConfigSource) (T, error) {
 type PersistableConfigSource interface {
 	ConfigSource
 	// Persist writes configuration changes back to the source.
-	Persist(k *koanf.Koanf, keyPrefix ...string) error
+	Persist(cm configManager, keyPrefix ...string) error
+}
+type configManager interface {
+	Get(string, ...any) (any, any, error)
+	Exists(key string) bool
+	Set(ctx context.Context, key string, value any) error
+	Delete(key string)
+	Keys() []string
+	Delim() string
+	All() map[string]any
 }

--- a/sync/dummy_test.go
+++ b/sync/dummy_test.go
@@ -206,7 +206,9 @@ func TestDummySyncClient_Configure(t *testing.T) {
 	assert.Equal(t, "sync.config", client.configNS)
 }
 
-type mockManager struct{}
+type mockManager struct {
+	data map[string]any
+}
 
 func (m *mockManager) Start(ctx context.Context) error { return nil }
 func (m *mockManager) Stop() error                     { return nil }
@@ -218,4 +220,30 @@ func (m *mockManager) Configure(manager configManager, namespace string) error {
 }
 func (m *mockManager) Get(key string, target ...any) (any, any, error) {
 	return nil, nil, nil
+}
+func (m *mockManager) All() map[string]any {
+	if m.data == nil {
+		m.data = make(map[string]any)
+	}
+	return m.data
+}
+func (m *mockManager) Delete(key string) {
+	delete(m.data, key)
+}
+func (m *mockManager) Delim() string {
+	return "."
+}
+func (m *mockManager) Keys() []string {
+	keys := make([]string, 0, len(m.data))
+	for k := range m.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+func (m *mockManager) Set(ctx context.Context, key string, value any) error {
+	if m.data == nil {
+		m.data = make(map[string]any)
+	}
+	m.data[key] = value
+	return nil
 }

--- a/sync/etcd_test.go
+++ b/sync/etcd_test.go
@@ -146,6 +146,14 @@ func TestEtcdSyncClient_Configure(t *testing.T) {
 
 type mockEtcdManager struct {
 	client etcd.EtcdClient
+	delim  string
+}
+
+func (m *mockEtcdManager) Delim() string {
+	if m.delim == "" {
+		return "."
+	}
+	return m.delim
 }
 
 func (m *mockEtcdManager) Client() etcd.EtcdClient {
@@ -174,7 +182,15 @@ func (m *mockEtcdManager) Close() error {
 }
 
 type mockConfigManager struct {
-	data map[string]any
+	data  map[string]any
+	delim string
+}
+
+func (m *mockConfigManager) Delim() string {
+	if m.delim == "" {
+		return "."
+	}
+	return m.delim
 }
 
 func (m *mockConfigManager) Get(key string, target ...any) (any, any, error) {
@@ -185,9 +201,36 @@ func (m *mockConfigManager) Get(key string, target ...any) (any, any, error) {
 	return val, nil, nil
 }
 
+func (m *mockConfigManager) All() map[string]any {
+	if m.data == nil {
+		m.data = make(map[string]any)
+	}
+	return m.data
+}
+
 func (m *mockConfigManager) Start(ctx context.Context) error { return nil }
 func (m *mockConfigManager) Stop() error                     { return nil }
 func (m *mockConfigManager) Push(ctx context.Context, key string, value any, callback PushCallback) error {
+	return nil
+}
+
+func (m *mockConfigManager) Delete(key string) {
+	delete(m.data, key)
+}
+
+func (m *mockConfigManager) Keys() []string {
+	keys := make([]string, 0, len(m.data))
+	for k := range m.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (m *mockConfigManager) Set(ctx context.Context, key string, value any) error {
+	if m.data == nil {
+		m.data = make(map[string]any)
+	}
+	m.data[key] = value
 	return nil
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -32,6 +32,11 @@ type Manager interface {
 }
 type configManager interface {
 	Get(string, ...any) (any, any, error)
+	Set(ctx context.Context, key string, value any) error
+	Delete(key string)
+	Keys() []string
+	Delim() string
+	All() map[string]any
 }
 
 type CManager = configManager


### PR DESCRIPTION
- Added missing methods to configManager interface (Delete, Keys, Delim)
- Modified all config sources to use configManager interface instead of direct koanf access
- Updated etcd source to properly handle nested maps and set values through config manager
- Added proper error handling for delete operations in memory source
- Fixed recursive Delete call in ConfigManagerDefault
- Added TestingInvalidSource for testing error cases
- Updated all tests to use mockManager that implements configManager
- Improved watch functionality to properly handle changes through config manager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration management with new capabilities to delete configuration keys, retrieve all keys, and access the delimiter used in configuration keys.
  - Configuration sources and managers now support a more flexible and generic interface, enabling improved extensibility and integration.
  - Added a test-only invalid configuration source for robust error handling testing.

- **Bug Fixes**
  - Improved error handling and validation in configuration management tests.

- **Refactor**
  - Replaced direct dependency on a specific configuration library with a generalized configuration manager interface across sources and tests, improving modularity and maintainability.

- **Tests**
  - Updated and expanded test coverage to use the new configuration manager abstraction, enhancing test robustness and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->