### PR TITLE
fix(defaults): match struct fields by name instead of tags

### DIFF
--- a/source/default.go
+++ b/source/default.go
@@ -106,27 +106,30 @@ func (d *DefaultConfigSource) Load(ctx context.Context, cm configManager) error 
 			// Get defaults from the struct
 			if defaults, ok := instance.(ConfigDefaults); ok {
 				for defKey, defValue := range defaults.Defaults() {
-					// Find matching field by exact tag or exact field name (with no tag)
-					var tagValue string
+					// Find field with matching name (case sensitive)
+					var fieldName string
 					found := false
 					for i := 0; i < typ.NumField(); i++ {
 						field := typ.Field(i)
-						tag := field.Tag.Get(d.tagName)
-						if tag == defKey {
-							tagValue = tag
-							found = true
-							break
+						// Skip unexported fields
+						if field.PkgPath != "" {
+							continue
 						}
-						if field.Name == defKey && tag == "" {
-							tagValue = field.Name
+						if field.Name == defKey {
+							// Use tag if present, otherwise use field name
+							if tag := field.Tag.Get(d.tagName); tag != "" {
+								fieldName = tag
+							} else {
+								fieldName = field.Name
+							}
 							found = true
 							break
 						}
 					}
 					if !found {
-						continue // Skip if no exact match found
+						continue // Skip if no matching field found
 					}
-					fullKey := key + "." + tagValue // Use dot since we're working with flattened map keys
+					fullKey := key + "." + fieldName // Use dot since we're working with flattened map keys
 					// Only set if key doesn't exist
 					if exists, _, _ := cm.Get(fullKey); exists == nil {
 						if err := cm.Set(ctx, fullKey, defValue); err != nil {

--- a/source/default_test.go
+++ b/source/default_test.go
@@ -235,8 +235,8 @@ type testConfigWithDefaults struct {
 
 func (t *testConfigWithDefaults) Defaults() map[string]any {
 	return map[string]any{
-		"host": "default_host",
-		"port": 8080,
+		"Host": "default_host",
+		"Port": 8080,
 	}
 }
 
@@ -391,7 +391,7 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("order of loading: struct defaults first, then static defaults", func(t *testing.T) {
 		mgr, dcs := setupDefaultConfigTest(t, map[string]any{"conflict.host": "static_host_override"}, "")
-		err := mgr.RegisterStruct("conflict", testConfigWithDefaults{}) // Defaults host to "default_host"
+		err := mgr.RegisterStruct("conflict", testConfigWithDefaults{}) // Defaults Host to "default_host"
 		assert.NoError(t, err)
 
 		err = dcs.Load(ctx, mgr)
@@ -429,11 +429,11 @@ type testConfig struct {
 
 func (t *testConfig) Defaults() map[string]any {
 	return map[string]any{
-		"field_one":   "value_one",   // Exact tag match
-		"FieldTwo":    "value_two",   // Exact field name match (no tag)
-		"fieldThree":  "value_three", // Should be skipped (unexported)
-		"field_four":  "value_four",  // Should be skipped (no match)
-		"FieldTwoAlt": "value_alt",   // Should be skipped (no match)
+		"FieldOne":   "value_one",   // Field name match (tag is "field_one")
+		"FieldTwo":   "value_two",   // Field name match (no tag)
+		"fieldThree": "value_three", // Should be skipped (unexported)
+		"field_four": "value_four",  // Should be skipped (no match)
+		"FieldTwoAlt": "value_alt",  // Should be skipped (no match)
 	}
 }
 
@@ -448,8 +448,8 @@ func TestDefaultConfigSource_Load_StructFieldMatching(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check expected values were set
-	mgr.assertValue(t, "test.field_one", "value_one")
-	mgr.assertValue(t, "test.FieldTwo", "value_two")
+	mgr.assertValue(t, "test.field_one", "value_one") // FieldOne's tag is "field_one"
+	mgr.assertValue(t, "test.FieldTwo", "value_two")  // FieldTwo has no tag so uses field name
 
 	// Check unexpected values were NOT set
 	_, _, err = mgr.Get("test.field_three")


### PR DESCRIPTION
Changed the default value application logic to:
- Match struct fields by exact field name (case sensitive) rather than tag values
- Skip unexported fields explicitly
- Use field name as key when tag is not present
- Updated tests to reflect new matching behavior

This provides more predictable behavior when applying defaults to structs, especially for fields without configuration tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in how default keys are matched to struct fields, now using exact field names (case sensitive) and skipping unexported fields.
  - Updated tests to reflect the new key matching logic, ensuring assertions use the correct field names.

- **Documentation**
  - Clarified comments to describe the updated approach for matching default keys to struct fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->