### PR TITLE
feat: add Root method for decoding entire config into struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -84,4 +84,9 @@ type Manager interface {
 
 	// Delimiter access
 	Delim() string
+
+	// Root decodes the entire configuration into the target struct.
+	// If target is nil, a new instance of the registered root struct type is created.
+	// Returns an error if no root struct is registered or if validation fails.
+	Root(target any) (any, error)
 }

--- a/manager.go
+++ b/manager.go
@@ -461,14 +461,15 @@ func (cm *ConfigManagerDefault) getIntoStruct(key string, target any) (any, erro
 				return nil, fmt.Errorf("target type %v does not match registered type %v",
 					targetType, structType)
 			}
-			cfg = reflect.ValueOf(target).Elem().Interface()
+			cfg = target
 		} else {
 			// For value target, must match registered type exactly
 			if targetType != structType {
 				return nil, fmt.Errorf("target type %v does not match registered type %v",
 					targetType, structType)
 			}
-			cfg = target
+			// Return error for value targets since we can't set into them
+			return nil, fmt.Errorf("target must be a pointer to decode into, got %T", target)
 		}
 	}
 
@@ -1087,6 +1088,13 @@ func (cm *ConfigManagerDefault) Delete(key string) {
 }
 
 // Delim returns the delimiter used for nested keys
+func (cm *ConfigManagerDefault) Root(target any) (any, error) {
+	if !cm.hasConfigStruct("") {
+		return nil, fmt.Errorf("no root configuration struct registered - use RegisterStruct(\"\", yourStruct{})")
+	}
+	return cm.getIntoStruct("", target)
+}
+
 func (cm *ConfigManagerDefault) Delim() string {
 	if cm.delimiter != "" {
 		return cm.delimiter

--- a/manager_test.go
+++ b/manager_test.go
@@ -1087,7 +1087,7 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 
 func TestConfigManager_ValidationControl(t *testing.T) {
 	cm := newTestManager()
-	
+
 	// Register a struct that requires validation
 	err := cm.RegisterStruct("test.validation", testStruct{})
 	require.NoError(t, err)
@@ -1159,6 +1159,62 @@ func TestConfigManager_ValidateRegisteredStructs(t *testing.T) {
 
 	err = cm.ValidateRegisteredStructs()
 	assert.NoError(t, err)
+}
+
+type rootConfig struct {
+	AppName string `config:"app_name"`
+	Debug   bool   `config:"debug"`
+}
+
+func TestConfigManager_Root(t *testing.T) {
+	cm := newTestManager()
+	err := cm.RegisterStruct("", rootConfig{})
+	require.NoError(t, err)
+
+	// Set some values
+	err = cm.Set(context.Background(), "app_name", "test_app")
+	require.NoError(t, err)
+	err = cm.Set(context.Background(), "debug", true)
+	require.NoError(t, err)
+
+	// Test with target
+	var target rootConfig
+	rootCfg, err := cm.Root(&target)
+	require.NoError(t, err)
+	assert.Equal(t, "test_app", target.AppName)
+	assert.Equal(t, true, target.Debug)
+	assert.Equal(t, &target, rootCfg)
+
+	// Test without target
+	rootCfg, err = cm.Root(nil)
+	require.NoError(t, err)
+	assert.IsType(t, &rootConfig{}, rootCfg)
+	assert.Equal(t, "test_app", rootCfg.(*rootConfig).AppName)
+	assert.Equal(t, true, rootCfg.(*rootConfig).Debug)
+
+	// Test error when no root struct registered
+	cm2 := newTestManager()
+	_, err = cm2.Root(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no root configuration struct registered")
+
+	// Test root struct decoding
+	cm3 := newTestManager()
+	err = cm3.RegisterStruct("", rootConfig{})
+	require.NoError(t, err)
+
+	// Set some values
+	err = cm3.Set(context.Background(), "app_name", "test_app")
+	require.NoError(t, err)
+	err = cm3.Set(context.Background(), "debug", true)
+	require.NoError(t, err)
+
+	// Test Root() with nil target
+	rootCfg, err = cm3.Root(nil)
+	require.NoError(t, err)
+	assert.IsType(t, &rootConfig{}, rootCfg)
+	assert.Equal(t, "test_app", rootCfg.(*rootConfig).AppName)
+	assert.Equal(t, true, rootCfg.(*rootConfig).Debug)
 }
 
 func TestConfigManager_ValidateWithZogSchema(t *testing.T) {


### PR DESCRIPTION
- Added new Root() method to ConfigManager interface and implementation
- Root() decodes entire configuration into registered root struct
- Supports both nil target (creates new instance) and pointer target
- Returns error if no root struct registered or validation fails
- Added comprehensive tests for Root() functionality
- Improved error message for non-pointer targets in getIntoStruct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to retrieve the full configuration as a structured object.
- **Bug Fixes**
	- Improved validation to ensure configuration decoding only works with pointer targets, preventing errors with non-pointer values.
- **Tests**
	- Introduced new tests to verify correct behavior when registering and retrieving root-level configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->