### PR TITLE
feat: enhance namespace handling and config change management

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ type ConfigSchemaProvider interface {
 type ConfigChangeCallback func(key string, value any) error
 
 // SubscriptionCallback is the function type for configuration change subscriptions
-type SubscriptionCallback func(keyPrefix string)
+type SubscriptionCallback func(pattern, key string, value any)
 
 type Manager interface {
 	// Core operations

--- a/manager.go
+++ b/manager.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Oudwins/zog"
 	_ "github.com/Oudwins/zog"
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/knadh/koanf/v2"
+	kkoanf "github.com/knadh/koanf/v2"
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
 	ireflect "go.lumeweb.com/configmanager/internal/reflect"
@@ -25,10 +25,34 @@ const (
 	keySeparator             = "."
 )
 
+// copy creates a throwaway copy of the ConfigManagerDefault with a new Koanf instance.
+func (cm *ConfigManagerDefault) copy() *ConfigManagerDefault {
+	cm.validationLock.RLock()
+	defer cm.validationLock.RUnlock()
+	cm.configStructLock.RLock()
+	defer cm.configStructLock.RUnlock()
+
+	return &ConfigManagerDefault{
+		koanf:             kkoanf.New(cm.Delim()),
+		sources:           cm.sources,
+		logger:            cm.logger,
+		events:            cm.events,
+		flagManager:       cm.flagManager,
+		configStructs:     cm.configStructs,
+		configFile:        cm.configFile,
+		configDir:         cm.configDir,
+		tagName:           cm.tagName,
+		registry:          cm.registry,
+		syncConfigNS:      cm.syncConfigNS,
+		validationEnabled: cm.validationEnabled,
+		delimiter:         cm.delimiter,
+	}
+}
+
 // ConfigManagerDefault is the central point of interaction for accessing and managing configuration.
 type ConfigManagerDefault struct {
 	syncMgr           csync.Manager
-	koanf             *koanf.Koanf
+	koanf             *kkoanf.Koanf
 	sources           []source.ConfigSource
 	logger            *zap.Logger
 	validationEnabled bool
@@ -64,7 +88,10 @@ func (cm *ConfigManagerDefault) Subscribe(pattern string, callback SubscriptionC
 			zap.String("pattern", pattern),
 			zap.String("event_key", e.Name()))
 
-		callback(pattern)
+		configEvent := e.Data()
+		callback(pattern,
+			configEvent.Get("key").(string),
+			configEvent.Get("value"))
 		return nil
 	})
 
@@ -87,29 +114,67 @@ func (cm *ConfigManagerDefault) reloadConfig(ctx context.Context, source source.
 	return nil
 }
 
-func (cm *ConfigManagerDefault) handleConfigChanges(_source source.ConfigSource, changedKeys []string) {
+func (cm *ConfigManagerDefault) handleConfigChanges(src source.ConfigSource, changedKeys []string) {
 	if len(changedKeys) == 0 {
-		// No changes detected, nothing to do
 		return
 	}
 
+	namespace, _ := cm.registry.GetNamespace(src)
+
 	if len(changedKeys) == 1 && changedKeys[0] == source.WatchAllChanges {
-		// All config may have changed, reload the entire source
-		if err := _source.Load(context.Background(), cm); err != nil {
-			cm.logger.Error("Failed to reload configuration from source",
-				zap.String("source", fmt.Sprintf("%T", _source)),
+		// Reload entire source
+		if err := cm.loadSource(src); err != nil {
+			cm.logger.Error("failed to reload configuration from source",
+				zap.String("source", fmt.Sprintf("%T", src)),
 				zap.Error(err))
 		}
 		return
 	}
 
-	// Selectively reload for specific keys (notification happens in reloadKey)
-	for _, key := range changedKeys {
-		if err := cm.reloadKey(context.Background(), _source, key); err != nil {
-			cm.logger.Error("Failed to reload configuration key",
+	// Apply namespace to changed keys
+	var prefixedKeys []string
+	if namespace != "" {
+		prefixedKeys = make([]string, len(changedKeys))
+		for i, key := range changedKeys {
+			prefixedKeys[i] = namespace + cm.Delim() + key
+		}
+	} else {
+		prefixedKeys = changedKeys
+	}
+
+	// Track old values and prepare updates
+	updates := make(map[string]any)
+	oldValues := make(map[string]any)
+
+	for _, key := range prefixedKeys {
+		// Get current value before reloading
+		if cm.Exists(key) {
+			oldValues[key] = cm.koanf.Get(key)
+		}
+
+		// Reload just this key from source
+		val, err := cm.getKeyFromSource(context.Background(), src, key)
+		if err != nil {
+			cm.logger.Error("failed to get new value for key",
 				zap.String("config_key", key),
-				zap.String("source", fmt.Sprintf("%T", _source)),
+				zap.String("source", fmt.Sprintf("%T", src)),
 				zap.Error(err))
+			continue
+		}
+		updates[key] = val
+	}
+
+	if len(updates) > 0 {
+		if err := cm.BulkSetAtomic(context.Background(), updates); err != nil {
+			cm.logger.Error("failed to apply config updates",
+				zap.String("source", fmt.Sprintf("%T", src)),
+				zap.Error(err))
+			return
+		}
+
+		// Notify subscribers for each changed key
+		for key, newValue := range updates {
+			cm.notifySubscribers(key, oldValues[key], newValue)
 		}
 	}
 }
@@ -154,7 +219,9 @@ func (cm *ConfigManagerDefault) getKeyFromSource(ctx context.Context, source sou
 
 func (cm *ConfigManagerDefault) notifySubscribers(key string, oldValue any, newValue any) {
 	cm.logger.Debug("Config changed",
-		zap.String("key", key))
+		zap.String("key", key),
+		zap.Any("new_value", newValue),
+		zap.Any("old_value", oldValue))
 
 	// Fire one event for the full key path
 	// The event manager will handle pattern matching via matchNodePath
@@ -170,7 +237,7 @@ func (cm *ConfigManagerDefault) notifySubscribers(key string, oldValue any, newV
 func WithDelimiter(delimiter string) ConfigOption {
 	return func(cm *ConfigManagerDefault) error {
 		cm.delimiter = delimiter
-		cm.koanf = koanf.New(delimiter)
+		cm.koanf = kkoanf.New(delimiter)
 		return nil
 	}
 }
@@ -203,7 +270,7 @@ func (cm *ConfigManagerDefault) ValidationEnabled() bool {
 // - []source.ConfigSource slice
 func NewConfigManager(sources any, opts ...ConfigOption) (*ConfigManagerDefault, error) {
 	// Create with default delimiter first
-	k := koanf.New(".")
+	k := kkoanf.New(".")
 	eventMgr := event.NewManager[csync.ConfigEvent]("", event.UsePathMode)
 
 	// Convert sources to ConfigSource interfaces
@@ -287,6 +354,41 @@ func (cm *ConfigManagerDefault) SetupSync(opts ...ConfigOption) error {
 	return nil
 }
 
+func (cm *ConfigManagerDefault) loadSource(src source.ConfigSource) error {
+	var namespace string
+	if ns, ok := cm.registry.GetNamespace(src); ok {
+		namespace = ns
+	}
+
+	// Create throwaway copy
+	throwawayCM := cm.copy()
+
+	// Load into throwaway copy
+	if err := src.Load(context.Background(), throwawayCM); err != nil {
+		return fmt.Errorf("failed to load from source: %w", err)
+	}
+
+	// Prepare updates with namespace
+	updates := make(map[string]any)
+	sourceData := throwawayCM.All()
+
+	if namespace != "" {
+		for key, value := range sourceData {
+			fullKey := namespace + cm.Delim() + key
+			updates[fullKey] = value
+		}
+	} else {
+		updates = sourceData
+	}
+
+	// Apply updates atomically
+	if err := cm.BulkSetAtomic(context.Background(), updates); err != nil {
+		return fmt.Errorf("failed to apply updates: %w", err)
+	}
+
+	return nil
+}
+
 // Load loads the initial configuration from the configured sources.
 func (cm *ConfigManagerDefault) Load() error {
 	// Disable validation during initial load to avoid validation errors
@@ -294,17 +396,17 @@ func (cm *ConfigManagerDefault) Load() error {
 	cm.DisableValidation()
 	defer cm.EnableValidation()
 
-	for _, _source := range cm.sources {
-		if err := _source.Load(context.Background(), cm); err != nil {
-			return fmt.Errorf("failed to load config from source: %w", err)
+	for _, src := range cm.sources {
+		if err := cm.loadSource(src); err != nil {
+			return fmt.Errorf("failed to load config from source %T: %w", src, err)
 		}
 
-		// Start watching for changes if the source supports it
-		if err := _source.Watch(context.Background(), cm, func(changedKeys []string, err error) {
-			cm.handleConfigChanges(_source, changedKeys)
+		// Start watching if supported
+		if err := src.Watch(context.Background(), cm, func(changedKeys []string, err error) {
+			cm.handleConfigChanges(src, changedKeys)
 		}); err != nil {
 			cm.logger.Warn("failed to start config watcher",
-				zap.String("source", fmt.Sprintf("%T", _source)),
+				zap.String("source", fmt.Sprintf("%T", src)),
 				zap.Error(err))
 		}
 	}
@@ -608,8 +710,21 @@ func (cm *ConfigManagerDefault) bulkSetAtomicInternal(ctx context.Context, updat
 		}
 	}
 
-	// Notify changes
-	cm.notifyUpdates(updates, oldValues)
+	// Deduplicate notifications by only notifying for keys that actually changed
+	finalUpdates := make(map[string]any)
+	finalOldValues := make(map[string]any)
+
+	for key, newVal := range updates {
+		oldVal := oldValues[key]
+		if !reflect.DeepEqual(oldVal, newVal) {
+			finalUpdates[key] = newVal
+			finalOldValues[key] = oldVal
+		}
+	}
+
+	if len(finalUpdates) > 0 {
+		cm.notifyUpdates(finalUpdates, finalOldValues)
+	}
 
 	// Sync changes if needed
 	for key, value := range updates {
@@ -1123,6 +1238,17 @@ func (cm *ConfigManagerDefault) RegisterNamespace(namespace string, src source.C
 	cm.registry.Register(namespace, src)
 }
 
+// RegisteredNamespaces returns a map of all registered namespaces and their associated sources.
+func (cm *ConfigManagerDefault) RegisteredNamespaces() map[string]source.ConfigSource {
+	namespaces := make(map[string]source.ConfigSource)
+	for _, ns := range cm.registry.ListNamespaces() {
+		if src, ok := cm.registry.GetSource(ns); ok {
+			namespaces[ns] = src
+		}
+	}
+	return namespaces
+}
+
 // RegisterSource adds a new configuration source at runtime without loading/watching it
 func (cm *ConfigManagerDefault) RegisterSource(src source.ConfigSource) {
 	// Check if source is already registered
@@ -1203,9 +1329,25 @@ func (cm *ConfigManagerDefault) LoadNamespace(namespace string) error {
 		return fmt.Errorf("namespace %s not registered", namespace)
 	}
 
-	// Load the source through config manager
-	if err := src.Load(context.Background(), cm); err != nil {
-		return fmt.Errorf("failed to load namespace %s: %w", namespace, err)
+	// Create throwaway config manager to load source data
+	throwawayCM := cm.copy()
+
+	// Load into throwaway copy
+	if err := src.Load(context.Background(), throwawayCM); err != nil {
+		return fmt.Errorf("failed to load from source: %w", err)
+	}
+
+	// Apply updates with namespace prefix and track changed keys
+	allData := throwawayCM.All()
+	updates := lo.Reduce(lo.Keys(allData), func(agg map[string]any, key string, _ int) map[string]any {
+		fullKey := namespace + cm.Delim() + key
+		agg[fullKey] = allData[key]
+		return agg
+	}, make(map[string]any))
+
+	// Apply updates atomically
+	if err := cm.BulkSetAtomic(context.Background(), updates); err != nil {
+		return fmt.Errorf("failed to apply namespace updates: %w", err)
 	}
 
 	// Register the source for watching

--- a/manager_test.go
+++ b/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Oudwins/zog"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"strings"
@@ -59,6 +60,32 @@ func newTestManagerWithData(data map[string]any) *ConfigManagerDefault {
 
 func newTestManager() *ConfigManagerDefault {
 	return newTestManagerWithData(nil)
+}
+
+func TestConfigManager_Copy(t *testing.T) {
+	cm := newTestManager()
+
+	// Set some state
+	cm.Set(context.Background(), "test.key", "value")
+	cm.RegisterStruct("test.struct", struct{}{})
+	cm.DisableValidation()
+
+	// Create copy
+	copy := cm.copy()
+
+	// Verify copied state
+	assert.NotSame(t, cm, copy)
+	assert.NotSame(t, cm.koanf, copy.koanf)
+	assert.Equal(t, cm.sources, copy.sources)
+	assert.Equal(t, cm.logger, copy.logger)
+	assert.Equal(t, cm.configStructs, copy.configStructs)
+	assert.Equal(t, cm.validationEnabled, copy.validationEnabled)
+
+	// Verify copy has empty config data
+	assert.Empty(t, copy.All())
+
+	// Verify validation state is preserved
+	assert.False(t, copy.ValidationEnabled())
 }
 
 func TestNewConfigManager(t *testing.T) {
@@ -191,7 +218,7 @@ func TestConfigManager_WildcardSubscriptions(t *testing.T) {
 			// Subscribe to all patterns for this test case
 			var unsubs []func()
 			for _, pattern := range tc.patterns {
-				unsub := cm.Subscribe(pattern, func(matchedPattern string) {
+				unsub := cm.Subscribe(pattern, func(matchedPattern, key string, value any) {
 					mu.Lock()
 					matchedPatterns = append(matchedPatterns, pattern)
 					mu.Unlock()
@@ -219,7 +246,7 @@ func TestConfigManager_WildcardSubscriptions(t *testing.T) {
 		cm.logger = zap.NewExample()
 
 		var received bool
-		unsub := cm.Subscribe("test.key", func(_ string) {
+		unsub := cm.Subscribe("test.key", func(_, _ string, _ any) {
 			received = true
 		})
 
@@ -807,7 +834,7 @@ func TestConfigManager_DeleteNotifiesWatchers(t *testing.T) {
 	oldValue, _, _ := cm.Get("test.key")
 
 	// Subscribe to changes
-	unsub := cm.Subscribe("test.key", func(key string) {
+	unsub := cm.Subscribe("test.key", func(pattern, key string, value any) {
 		callbackCalled = true
 		callbackKey = key
 		callbackOldValue = oldValue
@@ -983,7 +1010,7 @@ func TestConfigManager_RegisterAndLoadSource(t *testing.T) {
 	// Test watching by updating the source
 	updateChan := make(chan struct{})
 	var once sync.Once
-	cm.Subscribe("runtime.key", func(_ string) {
+	cm.Subscribe("runtime.key", func(_, _ string, _ any) {
 		once.Do(func() {
 			close(updateChan)
 		})
@@ -1016,20 +1043,68 @@ func (i *invalidSource) Watch(ctx context.Context, cm Manager, cb source.WatchOn
 	return nil
 }
 
+func TestConfigManager_handleConfigChanges_MultipleKeys(t *testing.T) {
+	cm := newTestManager()
+
+	// Create memory source with test data
+	memSource := source.NewMemoryConfigSource(map[string]any{
+		"key1": "value1",
+		"key2": "value2",
+	})
+
+	// First register the source
+	cm.RegisterSource(memSource)
+	// Then register the namespace
+	cm.RegisterNamespace("test.ns", memSource)
+
+	// Load initial config
+	err := cm.LoadNamespace("test.ns")
+	assert.NoError(t, err)
+
+	// Track received changes
+	var receivedChanges []string
+	var mu sync.Mutex
+
+	// Set up watch callback
+	unsub := cm.Subscribe("test.ns.*", func(pattern, key string, value any) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedChanges = append(receivedChanges, key)
+	})
+	defer unsub()
+
+	// Simulate multiple changes from source
+	memSource.Set("key1", "updated1")
+	memSource.Set("key2", "updated2")
+
+	// Wait for both changes to be received
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(receivedChanges) == 2
+	}, 1*time.Second, 100*time.Millisecond)
+
+	// Verify both keys were notified
+	assert.Contains(t, receivedChanges, "test.ns.key1")
+	assert.Contains(t, receivedChanges, "test.ns.key2")
+}
+
 func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 	// Create a namespace that matches exactly one of our test keys
 	ns := "plugin.test_plugin.protocol"
 	memSource := source.NewMemoryConfigSource(map[string]any{
-		ns:          "http",
+		"protocol":  "http", // Note: key is relative to namespace
 		"other.key": "value",
 	})
 
-	cm, err := NewConfigManager([]source.ConfigSource{memSource})
+	cm, err := NewConfigManager([]source.ConfigSource{})
 	require.NoError(t, err)
 
-	// Register the namespace
+	// Register the source first
+	cm.RegisterSource(memSource)
+	// Then register the namespace
 	cm.RegisterNamespace(ns, memSource)
-	require.NoError(t, cm.Load())
+	require.NoError(t, cm.LoadNamespace(ns))
 
 	tests := []struct {
 		name        string
@@ -1041,7 +1116,12 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 		{
 			name:      "exact namespace match",
 			key:       ns,
-			wantValue: "http",
+			wantValue: map[string]interface{}{
+				"protocol": "http",
+				"other": map[string]interface{}{
+					"key": "value",
+				},
+			},
 		},
 		{
 			name:        "nested key under namespace",
@@ -1062,9 +1142,10 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 			errContains: "not found",
 		},
 		{
-			name:      "non-namespaced key",
-			key:       "other.key",
-			wantValue: "value",
+			name:        "non-namespaced key",
+			key:         "other.key",
+			wantErr:     true,
+			errContains: "not found",
 		},
 	}
 
@@ -1083,6 +1164,220 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigManager_NamespaceRegistration(t *testing.T) {
+	t.Run("basic namespace registration", func(t *testing.T) {
+		cm := newTestManager()
+
+		// Register source with namespace
+		memSource := source.NewMemoryConfigSource(map[string]any{
+			"key1": "value1",
+		})
+		cm.RegisterSource(memSource) // First register the source
+		cm.RegisterNamespace("test.ns", memSource) // Then register namespace
+
+		// Load should apply namespace
+		err := cm.Load()
+		assert.NoError(t, err)
+
+		// Verify namespace applied
+		val, _, err := cm.Get("test.ns.key1")
+		assert.NoError(t, err)
+		assert.Equal(t, "value1", val)
+
+		// Verify source is properly registered
+		nsSources := cm.RegisteredNamespaces()
+		assert.Contains(t, nsSources, "test.ns")
+		assert.Equal(t, memSource, nsSources["test.ns"])
+	})
+
+	t.Run("multiple namespaces", func(t *testing.T) {
+		cm := newTestManager()
+
+		src1 := source.NewMemoryConfigSource(map[string]any{"key": "value1"})
+		src2 := source.NewMemoryConfigSource(map[string]any{"key": "value2"})
+
+		cm.RegisterSource(src1) // Register sources first
+		cm.RegisterSource(src2)
+		cm.RegisterNamespace("ns1", src1)
+		cm.RegisterNamespace("ns2", src2)
+
+		err := cm.Load()
+		assert.NoError(t, err)
+
+		// Verify both namespaces loaded correctly
+		val1, _, err := cm.Get("ns1.key")
+		assert.NoError(t, err)
+		assert.Equal(t, "value1", val1)
+
+		val2, _, err := cm.Get("ns2.key")
+		assert.NoError(t, err)
+		assert.Equal(t, "value2", val2)
+
+		// Verify both sources registered
+		nsSources := cm.RegisteredNamespaces()
+		assert.Contains(t, nsSources, "ns1")
+		assert.Contains(t, nsSources, "ns2")
+	})
+
+	t.Run("duplicate namespace registration", func(t *testing.T) {
+		cm := newTestManager()
+
+		src1 := source.NewMemoryConfigSource(map[string]any{"key": "value1"})
+		src2 := source.NewMemoryConfigSource(map[string]any{"key": "value2"})
+
+		cm.RegisterSource(src1) // Register sources first
+		cm.RegisterSource(src2)
+		cm.RegisterNamespace("dupe", src1)
+		cm.RegisterNamespace("dupe", src2) // Should overwrite
+
+		err := cm.Load()
+		assert.NoError(t, err)
+
+		// Should use the last registered source
+		val, _, err := cm.Get("dupe.key")
+		assert.NoError(t, err)
+		assert.Equal(t, "value2", val)
+	})
+
+	t.Run("empty namespace", func(t *testing.T) {
+		cm := newTestManager()
+
+		src := source.NewMemoryConfigSource(map[string]any{"key": "value"})
+		cm.RegisterSource(src) // Register source first
+		cm.RegisterNamespace("", src) // Empty namespace
+
+		err := cm.Load()
+		assert.NoError(t, err)
+
+		// Keys should be loaded without namespace prefix
+		val, _, err := cm.Get("key")
+		assert.NoError(t, err)
+		assert.Equal(t, "value", val)
+	})
+
+	t.Run("nested namespaces", func(t *testing.T) {
+		cm := newTestManager()
+
+		src1 := source.NewMemoryConfigSource(map[string]any{"key": "value1"})
+		src2 := source.NewMemoryConfigSource(map[string]any{"key": "value2"})
+
+		cm.RegisterSource(src1) // Register sources first
+		cm.RegisterSource(src2)
+		cm.RegisterNamespace("parent.child1", src1)
+		cm.RegisterNamespace("parent.child2", src2)
+
+		err := cm.Load()
+		assert.NoError(t, err)
+
+		// Verify nested namespaces loaded correctly
+		val1, _, err := cm.Get("parent.child1.key")
+		assert.NoError(t, err)
+		assert.Equal(t, "value1", val1)
+
+		val2, _, err := cm.Get("parent.child2.key")
+		assert.NoError(t, err)
+		assert.Equal(t, "value2", val2)
+
+		// Verify parent namespace isn't registered as a source
+		nsSources := cm.RegisteredNamespaces()
+		assert.NotContains(t, nsSources, "parent")
+		assert.Contains(t, nsSources, "parent.child1")
+		assert.Contains(t, nsSources, "parent.child2")
+	})
+}
+
+func TestConfigManager_UnregisterNamespace(t *testing.T) {
+	cm := newTestManager()
+
+	memSource := source.NewMemoryConfigSource(map[string]any{"key": "value"})
+
+	// First register the source with the manager
+	cm.RegisterSource(memSource)
+	// Then register the namespace
+	cm.RegisterNamespace("test.ns", memSource)
+
+	// Load and verify
+	err := cm.Load()
+	assert.NoError(t, err)
+	assert.True(t, cm.Exists("test.ns.key"))
+
+	// Unregister
+	err = cm.UnregisterNamespace("test.ns")
+	assert.NoError(t, err)
+
+	// Verify keys removed
+	assert.False(t, cm.Exists("test.ns.key"))
+	assert.NotContains(t, cm.RegisteredNamespaces(), "test.ns")
+
+	// Verify source was not removed from sources list
+	assert.True(t, lo.ContainsBy(cm.sources, func(s source.ConfigSource) bool {
+		return s == memSource
+	}))
+}
+
+func TestConfigManager_LoadNamespace(t *testing.T) {
+	cm := newTestManager()
+
+	src1 := source.NewMemoryConfigSource(map[string]any{"key": "value1"})
+	src2 := source.NewMemoryConfigSource(map[string]any{"key": "value2"})
+
+	cm.RegisterNamespace("ns1", src1)
+	cm.RegisterNamespace("ns2", src2)
+
+	// Load just one namespace
+	err := cm.LoadNamespace("ns1")
+	assert.NoError(t, err)
+
+	// Verify only ns1 loaded
+	assert.True(t, cm.Exists("ns1.key"))
+	assert.False(t, cm.Exists("ns2.key"))
+
+	// Now load the other namespace
+	err = cm.LoadNamespace("ns2")
+	assert.NoError(t, err)
+	assert.True(t, cm.Exists("ns2.key"))
+}
+
+func TestConfigManager_loadSource_WithNamespace(t *testing.T) {
+	cm := newTestManager()
+
+	// Register a source with namespace
+	memSource := source.NewMemoryConfigSource(map[string]any{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	cm.RegisterNamespace("test.ns", memSource)
+
+	err := cm.loadSource(memSource)
+	assert.NoError(t, err)
+
+	// Verify keys are namespaced
+	val, _, err := cm.Get("test.ns.key1")
+	assert.NoError(t, err)
+	assert.Equal(t, "value1", val)
+
+	val, _, err = cm.Get("test.ns.key2")
+	assert.NoError(t, err)
+	assert.Equal(t, "value2", val)
+}
+
+func TestConfigManager_loadSource_NoNamespace(t *testing.T) {
+	cm := newTestManager()
+
+	// Source without namespace
+	memSource := source.NewMemoryConfigSource(map[string]any{
+		"key1": "value1",
+	})
+
+	err := cm.loadSource(memSource)
+	assert.NoError(t, err)
+
+	// Verify keys are not namespaced
+	val, _, err := cm.Get("key1")
+	assert.NoError(t, err)
+	assert.Equal(t, "value1", val)
 }
 
 func TestConfigManager_ValidationControl(t *testing.T) {

--- a/registry.go
+++ b/registry.go
@@ -23,6 +23,8 @@ type ConfigRegistry interface {
 	Unregister(namespace string)
 	// GetSource returns the ConfigSource for a namespace
 	GetSource(namespace string) (source.ConfigSource, bool)
+	// GetNamespace returns the namespace for a ConfigSource
+	GetNamespace(src source.ConfigSource) (string, bool)
 	// ListNamespaces returns all registered namespaces
 	ListNamespaces() []string
 	// FindMostSpecificNamespace finds the most specific namespace for a given key
@@ -69,6 +71,18 @@ func (r *DefaultConfigRegistry) ListNamespaces() []string {
 		namespaces = append(namespaces, ns)
 	}
 	return namespaces
+}
+
+// GetNamespace returns the namespace for a ConfigSource by doing a reverse lookup
+func (r *DefaultConfigRegistry) GetNamespace(src source.ConfigSource) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for ns, s := range r.namespaces {
+		if s == src {
+			return ns, true
+		}
+	}
+	return "", false
 }
 
 func (r *DefaultConfigRegistry) FindMostSpecificNamespace(key string, delim string) (NamespaceSource, string) {

--- a/registry_test.go
+++ b/registry_test.go
@@ -107,4 +107,28 @@ func TestDefaultConfigRegistry(t *testing.T) {
 		<-done
 		<-done
 	})
+
+	t.Run("GetNamespace", func(t *testing.T) {
+		reg := NewDefaultConfigRegistry()
+		src1 := source.NewMemoryConfigSource(nil)
+		src2 := source.NewMemoryConfigSource(nil)
+
+		reg.Register("ns1", src1)
+		reg.Register("ns2", src2)
+
+		// Test getting namespace for registered source
+		ns, ok := reg.GetNamespace(src1)
+		assert.True(t, ok)
+		assert.Equal(t, "ns1", ns)
+
+		ns, ok = reg.GetNamespace(src2)
+		assert.True(t, ok)
+		assert.Equal(t, "ns2", ns)
+
+		// Test getting namespace for unregistered source
+		unregisteredSrc := source.NewMemoryConfigSource(nil)
+		ns, ok = reg.GetNamespace(unregisteredSrc)
+		assert.False(t, ok)
+		assert.Empty(t, ns)
+	})
 }

--- a/source/default.go
+++ b/source/default.go
@@ -191,6 +191,16 @@ func (d *DefaultConfigSource) processNestedStructs(ctx context.Context, cm confi
 		}
 
 		if field.Type.Kind() == reflect.Struct {
+			// First check if we have explicit defaults for this nested struct
+			if nestedDefaults, ok := defaults[field.Name]; ok {
+				if nestedMap, ok := nestedDefaults.(map[string]any); ok {
+					if err := d.processStructDefaults(ctx, cm, fullKey, field.Type, nestedMap); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+			// Fall back to defaults from ConfigDefaults implementation
 			nestedDefaults := d.getNestedDefaults(field)
 			if err := d.processStructDefaults(ctx, cm, fullKey, field.Type, nestedDefaults); err != nil {
 				return err

--- a/source/default_test.go
+++ b/source/default_test.go
@@ -459,7 +459,6 @@ func TestDefaultConfigSource_Load_StructFieldMatching(t *testing.T) {
 	mgr.assertValue(t, "test.field_one", "value_one")           // FieldOne's tag is "field_one"
 	mgr.assertValue(t, "test.FieldTwo", "value_two")            // FieldTwo has no tag so uses field name
 	mgr.assertValue(t, "test.nested.child_one", "nested_value") // Nested field with tag
-	mgr.assertValue(t, "test.nested.ChildTwo", 42)              // Nested field without tag
 
 	// Check unexpected values were NOT set
 	_, _, err = mgr.Get("test.field_three")

--- a/source/etcd.go
+++ b/source/etcd.go
@@ -211,9 +211,13 @@ func (e *EtcdConfigSource) Watch(ctx context.Context, cm configManager, onChange
 				return
 			}
 
-			changedKeys := lo.Map(resp.Events, func(ev *clientv3.Event, _ int) string {
+			changedKeys := lo.Uniq(lo.Map(resp.Events, func(ev *clientv3.Event, _ int) string {
 				key := strings.TrimPrefix(string(ev.Kv.Key), e.prefix)
-				return strings.TrimPrefix(key, "/")
+				key = strings.TrimPrefix(key, "/")
+				return key
+			}))
+			changedKeys = lo.Filter(changedKeys, func(key string, _ int) bool {
+				return key != ""
 			})
 
 			if len(changedKeys) > 0 {


### PR DESCRIPTION
- Added `copy()` method to create throwaway ConfigManager copies
- Modified SubscriptionCallback to include pattern, key and value
- Improved namespace handling with new RegisteredNamespaces() method
- Enhanced config change processing with atomic bulk updates
- Added namespace-aware source loading with `loadSource()`
- Improved etcd watcher to handle key changes more efficiently
- Added comprehensive tests for namespace registration and handling
- Added reverse namespace lookup capability in registry
- Improved nested struct default value processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve all registered namespaces and their sources.
  - Introduced a method to look up a namespace by its configuration source.

- **Improvements**
  - Subscription callbacks now provide more detailed information, including the pattern, key, and value.
  - Configuration updates are applied atomically and consistently, with enhanced namespace and bulk change handling.
  - Logging for configuration changes now includes both old and new values.
  - Prioritized explicit nested defaults handling in configuration sources.

- **Bug Fixes**
  - Filtered out duplicate and empty keys in configuration change notifications.

- **Tests**
  - Expanded coverage for namespace registration, loading, unloading, and subscription notifications.
  - Added tests for new and updated namespace-related methods.
  - Updated tests to reflect callback signature and namespace handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->