### PR TITLE
feat: add global config source support

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -360,7 +360,13 @@ func (cm *ConfigManagerDefault) loadSource(src source.ConfigSource) error {
 		namespace = ns
 	}
 
-	// Create throwaway copy
+	// Check if source should be loaded globally
+	if globalSrc, ok := src.(source.GlobalConfigSource); ok && globalSrc.IsGlobal() {
+		// Load directly into main config manager
+		return src.Load(context.Background(), cm)
+	}
+
+	// Create throwaway copy for isolated loading
 	throwawayCM := cm.copy()
 
 	// Load into throwaway copy

--- a/manager_test.go
+++ b/manager_test.go
@@ -1166,6 +1166,80 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 	}
 }
 
+func TestConfigManager_GlobalSources(t *testing.T) {
+	t.Run("global env source", func(t *testing.T) {
+		// Create global env source
+		envSrc := source.NewEnvConfigSource("TEST_", "_", source.WithEnvGlobal())
+		
+		// Create manager with the source
+		cm, err := NewConfigManager([]source.ConfigSource{envSrc})
+		require.NoError(t, err)
+
+		// Set some env vars
+		t.Setenv("TEST_DB_HOST", "localhost")
+		t.Setenv("TEST_DB_PORT", "5432")
+
+		// Load config
+		err = cm.Load()
+		require.NoError(t, err)
+
+		// Verify keys are loaded without namespace
+		assert.True(t, cm.Exists("db.host"))
+		assert.Equal(t, "localhost", cm.koanf.Get("db.host"))
+		assert.True(t, cm.Exists("db.port"))
+		assert.Equal(t, "5432", cm.koanf.Get("db.port"))
+	})
+
+	t.Run("global default source", func(t *testing.T) {
+		// Create manager first
+		cm := newTestManager()
+
+		// Create global default source
+		defaults := map[string]any{
+			"app.name": "TestApp",
+			"app.port": 8000,
+		}
+		defaultSrc := source.NewDefaultConfigSource(cm, 
+			source.WithDefaults(defaults),
+			source.WithGlobal(true))
+
+		// Register and load the source
+		cm.RegisterSource(defaultSrc)
+		err := cm.LoadSource(defaultSrc, true, false)
+		require.NoError(t, err)
+
+		// Verify keys are loaded without namespace
+		assert.True(t, cm.Exists("app.name"))
+		assert.Equal(t, "TestApp", cm.koanf.Get("app.name"))
+		assert.True(t, cm.Exists("app.port"))
+		assert.Equal(t, 8000, cm.koanf.Get("app.port"))
+	})
+
+	t.Run("non-global sources still use namespaces", func(t *testing.T) {
+		// Create non-global env source with namespace
+		envSrc := source.NewEnvConfigSource("TEST_", "_") // No WithEnvGlobal()
+		
+		// Create manager and register namespace
+		cm, err := NewConfigManager([]source.ConfigSource{envSrc})
+		require.NoError(t, err)
+		cm.RegisterNamespace("test", envSrc)
+
+		// Set some env vars
+		t.Setenv("TEST_DB_HOST", "localhost")
+		t.Setenv("TEST_DB_PORT", "5432")
+
+		// Load config
+		err = cm.Load()
+		require.NoError(t, err)
+
+		// Verify keys are loaded with namespace
+		assert.True(t, cm.Exists("test.db.host"))
+		assert.Equal(t, "localhost", cm.koanf.Get("test.db.host"))
+		assert.True(t, cm.Exists("test.db.port"))
+		assert.Equal(t, "5432", cm.koanf.Get("test.db.port"))
+	})
+}
+
 func TestConfigManager_NamespaceRegistration(t *testing.T) {
 	t.Run("basic namespace registration", func(t *testing.T) {
 		cm := newTestManager()

--- a/source/default.go
+++ b/source/default.go
@@ -17,6 +17,12 @@ type DefaultConfigSource struct {
 	defaults map[string]any
 	manager  manager
 	tagName  string
+	global   bool // Controls whether this source should be loaded globally
+}
+
+// IsGlobal implements GlobalConfigSource
+func (d *DefaultConfigSource) IsGlobal() bool {
+	return d.global
 }
 
 type manager interface {
@@ -29,6 +35,7 @@ type manager interface {
 type DefaultConfigOptions struct {
 	defaults map[string]any
 	tagName  string
+	global   bool
 }
 
 // DefaultConfigOption defines the option function type
@@ -48,12 +55,20 @@ func WithTagName(tagName string) DefaultConfigOption {
 	}
 }
 
+// WithGlobal sets whether this source should be loaded globally
+func WithGlobal(global bool) DefaultConfigOption {
+	return func(o *DefaultConfigOptions) {
+		o.global = global
+	}
+}
+
 // NewDefaultConfigSource creates a new DefaultConfigSource.
 // The defaults map can contain nested values using dot notation keys (e.g. "database.host").
 func NewDefaultConfigSource(manager manager, opts ...DefaultConfigOption) *DefaultConfigSource {
 	// Set defaults
 	options := DefaultConfigOptions{
 		tagName: "config",
+		global:  false, // Default to non-global behavior
 	}
 
 	// Apply options

--- a/source/env.go
+++ b/source/env.go
@@ -13,16 +13,34 @@ import (
 type EnvConfigSource struct {
 	prefix    string
 	delimiter string
+	global    bool // Controls whether this source should be loaded globally
+}
+
+// IsGlobal implements GlobalConfigSource
+func (e *EnvConfigSource) IsGlobal() bool {
+	return e.global
 }
 
 // NewEnvConfigSource creates a new EnvConfigSource with optional prefix and delimiter.
 // The prefix is prepended to environment variable names (e.g. "APP_").
 // The delimiter is used to split nested keys (e.g. "_" for "APP_DB_HOST").
-func NewEnvConfigSource(prefix, delimiter string) *EnvConfigSource {
-	return &EnvConfigSource{
+type EnvConfigOption func(*EnvConfigSource)
+
+func WithEnvGlobal() EnvConfigOption {
+	return func(e *EnvConfigSource) {
+		e.global = true
+	}
+}
+
+func NewEnvConfigSource(prefix, delimiter string, opts ...EnvConfigOption) *EnvConfigSource {
+	e := &EnvConfigSource{
 		prefix:    prefix,
 		delimiter: delimiter,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // Load loads the configuration from environment variables into the config manager.

--- a/source/source.go
+++ b/source/source.go
@@ -14,6 +14,13 @@ type ConfigSource interface {
 	Watch(ctx context.Context, cm configManager, onChange WatchOnChangeCallback) error
 }
 
+// GlobalConfigSource marks a ConfigSource that should be loaded globally without namespace isolation
+type GlobalConfigSource interface {
+	ConfigSource
+	// IsGlobal returns true if this source should be loaded globally
+	IsGlobal() bool
+}
+
 // WatchAllChanges is a special value that indicates all configuration values may have changed.
 // This should be used when the source detects a broad change but can't determine exactly which keys changed.
 const WatchAllChanges = "*"


### PR DESCRIPTION
- Add GlobalConfigSource interface to mark sources that should bypass namespace isolation
- Implement IsGlobal() for DefaultConfigSource and EnvConfigSource
- Modify ConfigManager to check for global sources and load them directly
- Add tests for global source behavior
- Update NewEnvConfigSource to accept options pattern for global flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for marking configuration sources as global, allowing them to load settings directly into the main configuration without namespace prefixes.
  - Introduced options to create global environment and default configuration sources.
- **Bug Fixes**
  - Ensured correct handling of global and non-global configuration sources, preventing unintended namespacing.
- **Tests**
  - Added tests to verify the behavior of global and non-global configuration sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->