### PR TITLE
refactor(source): rename option functions for consistency

### DIFF
--- a/source/default.go
+++ b/source/default.go
@@ -41,24 +41,24 @@ type DefaultConfigOptions struct {
 // DefaultConfigOption defines the option function type
 type DefaultConfigOption func(*DefaultConfigOptions)
 
-// WithDefaults sets the default values map
-func WithDefaults(defaults map[string]any) DefaultConfigOption {
+// WithDefaultSourceDefaults sets the default values map
+func WithDefaultSourceDefaults(defaults map[string]any) DefaultConfigOption {
 	return func(o *DefaultConfigOptions) {
 		o.defaults = defaults
 	}
 }
 
-// WithTagName sets the struct tag name to use (default: "config")
-func WithTagName(tagName string) DefaultConfigOption {
+// WithDefaultSourceTagName sets the struct tag name to use (default: "config")
+func WithDefaultSourceTagName(tagName string) DefaultConfigOption {
 	return func(o *DefaultConfigOptions) {
 		o.tagName = tagName
 	}
 }
 
-// WithGlobal sets whether this source should be loaded globally
-func WithGlobal(global bool) DefaultConfigOption {
+// WithDefaultSourceGlobal marks this source to be loaded globally
+func WithDefaultSourceGlobal() DefaultConfigOption {
 	return func(o *DefaultConfigOptions) {
-		o.global = global
+		o.global = true
 	}
 }
 

--- a/source/env.go
+++ b/source/env.go
@@ -26,7 +26,7 @@ func (e *EnvConfigSource) IsGlobal() bool {
 // The delimiter is used to split nested keys (e.g. "_" for "APP_DB_HOST").
 type EnvConfigOption func(*EnvConfigSource)
 
-func WithEnvGlobal() EnvConfigOption {
+func WithEnvSourceGlobal() EnvConfigOption {
 	return func(e *EnvConfigSource) {
 		e.global = true
 	}


### PR DESCRIPTION
- Rename WithDefaults to WithDefaultSourceDefaults in default.go
- Rename WithTagName to WithDefaultSourceTagName in default.go
- Change WithGlobal to WithDefaultSourceGlobal and make it parameterless
- Rename WithEnvGlobal to WithEnvSourceGlobal in env.go

These changes make the option function names more consistent by:
1. Including "Source" in the name to indicate they configure sources
2. Following a consistent naming pattern across source types
3. Simplifying WithDefaultSourceGlobal to be parameterless since it just sets true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed several configuration option functions for improved clarity in their naming.
  - Updated comments to match new function names and behaviors.
  - Adjusted one configuration option to always enable a setting, removing its parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->