### PR TITLE
fix(default): set global flag in default source configuration

### DIFF
--- a/source/default.go
+++ b/source/default.go
@@ -92,6 +92,7 @@ func NewDefaultConfigSource(manager manager, opts ...DefaultConfigOption) *Defau
 		defaults: flatDefaults,
 		manager:  manager,
 		tagName:  options.tagName,
+		global:   options.global,
 	}
 }
 


### PR DESCRIPTION
Ensures the global field is properly initialized in the default source struct to correctly implement the GlobalConfigSource interface.

This fixes an issue where default values weren't being properly marked as global configuration.