### PR TITLE
refactor: simplify namespace loading by delegating to loadSource

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1335,25 +1335,9 @@ func (cm *ConfigManagerDefault) LoadNamespace(namespace string) error {
 		return fmt.Errorf("namespace %s not registered", namespace)
 	}
 
-	// Create throwaway config manager to load source data
-	throwawayCM := cm.copy()
-
-	// Load into throwaway copy
-	if err := src.Load(context.Background(), throwawayCM); err != nil {
-		return fmt.Errorf("failed to load from source: %w", err)
-	}
-
-	// Apply updates with namespace prefix and track changed keys
-	allData := throwawayCM.All()
-	updates := lo.Reduce(lo.Keys(allData), func(agg map[string]any, key string, _ int) map[string]any {
-		fullKey := namespace + cm.Delim() + key
-		agg[fullKey] = allData[key]
-		return agg
-	}, make(map[string]any))
-
-	// Apply updates atomically
-	if err := cm.BulkSetAtomic(context.Background(), updates); err != nil {
-		return fmt.Errorf("failed to apply namespace updates: %w", err)
+	// Delegate to loadSource which handles both global and namespaced loading
+	if err := cm.loadSource(src); err != nil {
+		return fmt.Errorf("failed to load namespace %s: %w", namespace, err)
 	}
 
 	// Register the source for watching


### PR DESCRIPTION
Replaced the manual namespace loading logic in LoadNamespace() with a delegation to the existing loadSource() method which already handles both global and namespaced loading scenarios. This:

1. Removes duplicate code
2. Ensures consistent loading behavior
3. Maintains the same functionality while being more maintainable

The change keeps all existing behavior including atomic updates and error handling while reducing complexity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal process for loading configuration namespaces, resulting in more efficient and reliable namespace loading. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->