### PR TITLE
fix: correct invalid config source option functions that caused compile errors

### DIFF
--- a/manager_test.go
+++ b/manager_test.go
@@ -1114,8 +1114,8 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 		errContains string
 	}{
 		{
-			name:      "exact namespace match",
-			key:       ns,
+			name: "exact namespace match",
+			key:  ns,
 			wantValue: map[string]interface{}{
 				"protocol": "http",
 				"other": map[string]interface{}{
@@ -1169,8 +1169,8 @@ func TestConfigManager_NamespaceKeyHandling(t *testing.T) {
 func TestConfigManager_GlobalSources(t *testing.T) {
 	t.Run("global env source", func(t *testing.T) {
 		// Create global env source
-		envSrc := source.NewEnvConfigSource("TEST_", "_", source.WithEnvGlobal())
-		
+		envSrc := source.NewEnvConfigSource("TEST_", "_", source.WithEnvSourceGlobal())
+
 		// Create manager with the source
 		cm, err := NewConfigManager([]source.ConfigSource{envSrc})
 		require.NoError(t, err)
@@ -1199,9 +1199,9 @@ func TestConfigManager_GlobalSources(t *testing.T) {
 			"app.name": "TestApp",
 			"app.port": 8000,
 		}
-		defaultSrc := source.NewDefaultConfigSource(cm, 
-			source.WithDefaults(defaults),
-			source.WithGlobal(true))
+		defaultSrc := source.NewDefaultConfigSource(cm,
+			source.WithDefaultSourceDefaults(defaults),
+			source.WithDefaultSourceGlobal())
 
 		// Register and load the source
 		cm.RegisterSource(defaultSrc)
@@ -1218,7 +1218,7 @@ func TestConfigManager_GlobalSources(t *testing.T) {
 	t.Run("non-global sources still use namespaces", func(t *testing.T) {
 		// Create non-global env source with namespace
 		envSrc := source.NewEnvConfigSource("TEST_", "_") // No WithEnvGlobal()
-		
+
 		// Create manager and register namespace
 		cm, err := NewConfigManager([]source.ConfigSource{envSrc})
 		require.NoError(t, err)
@@ -1248,7 +1248,7 @@ func TestConfigManager_NamespaceRegistration(t *testing.T) {
 		memSource := source.NewMemoryConfigSource(map[string]any{
 			"key1": "value1",
 		})
-		cm.RegisterSource(memSource) // First register the source
+		cm.RegisterSource(memSource)               // First register the source
 		cm.RegisterNamespace("test.ns", memSource) // Then register namespace
 
 		// Load should apply namespace
@@ -1319,7 +1319,7 @@ func TestConfigManager_NamespaceRegistration(t *testing.T) {
 		cm := newTestManager()
 
 		src := source.NewMemoryConfigSource(map[string]any{"key": "value"})
-		cm.RegisterSource(src) // Register source first
+		cm.RegisterSource(src)        // Register source first
 		cm.RegisterNamespace("", src) // Empty namespace
 
 		err := cm.Load()

--- a/source/default_test.go
+++ b/source/default_test.go
@@ -15,10 +15,10 @@ func setupDefaultConfigTest(t *testing.T, defaults map[string]any, tagName strin
 	mgr := newMockManager()
 	var opts []DefaultConfigOption
 	if defaults != nil {
-		opts = append(opts, WithDefaults(defaults))
+		opts = append(opts, WithDefaultSourceDefaults(defaults))
 	}
 	if tagName != "" {
-		opts = append(opts, WithTagName(tagName))
+		opts = append(opts, WithDefaultSourceTagName(tagName))
 	}
 	return mgr, NewDefaultConfigSource(mgr, opts...)
 }
@@ -227,13 +227,13 @@ func (m *mockManager) assertValue(t *testing.T, key string, expected any) {
 	}
 }
 
-// testConfigWithDefaults implements ConfigDefaults
-type testConfigWithDefaults struct {
+// testConfigWithDefaultSourceDefaults implements ConfigDefaults
+type testConfigWithDefaultSourceDefaults struct {
 	Host string `config:"host"`
 	Port int    `config:"port"`
 }
 
-func (t *testConfigWithDefaults) Defaults() map[string]any {
+func (t *testConfigWithDefaultSourceDefaults) Defaults() map[string]any {
 	return map[string]any{
 		"Host": "default_host",
 		"Port": 8080,
@@ -262,7 +262,7 @@ func TestNewDefaultConfigSource(t *testing.T) {
 	})
 
 	t.Run("empty defaults", func(t *testing.T) {
-		dcs := NewDefaultConfigSource(mgr, WithDefaults(map[string]any{}))
+		dcs := NewDefaultConfigSource(mgr, WithDefaultSourceDefaults(map[string]any{}))
 		assert.NotNil(t, dcs)
 		assert.Empty(t, dcs.defaults)
 	})
@@ -272,7 +272,7 @@ func TestNewDefaultConfigSource(t *testing.T) {
 			"key1": "value1",
 			"key2": 123,
 		}
-		dcs := NewDefaultConfigSource(mgr, WithDefaults(defaults), WithTagName("config"))
+		dcs := NewDefaultConfigSource(mgr, WithDefaultSourceDefaults(defaults), WithDefaultSourceTagName("config"))
 		assert.NotNil(t, dcs)
 		assert.Equal(t, defaults, dcs.defaults)
 	})
@@ -290,7 +290,7 @@ func TestNewDefaultConfigSource(t *testing.T) {
 			"parent.child2": true,
 			"key1":          123,
 		}
-		dcs := NewDefaultConfigSource(mgr, WithDefaults(defaults))
+		dcs := NewDefaultConfigSource(mgr, WithDefaultSourceDefaults(defaults))
 		assert.NotNil(t, dcs)
 		assert.Equal(t, expectedFlatDefaults, dcs.defaults)
 	})
@@ -315,7 +315,7 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("load struct defaults", func(t *testing.T) {
 		mgr, dcs := setupDefaultConfigTest(t, nil, "config")
-		err := mgr.RegisterStruct("db", testConfigWithDefaults{})
+		err := mgr.RegisterStruct("db", testConfigWithDefaultSourceDefaults{})
 		assert.NoError(t, err)
 
 		err = dcs.Load(ctx, mgr)
@@ -362,7 +362,7 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("struct defaults do not overwrite existing values", func(t *testing.T) {
 		mgr, dcs := setupDefaultConfigTest(t, nil, "")
-		err := mgr.RegisterStruct("db", testConfigWithDefaults{})
+		err := mgr.RegisterStruct("db", testConfigWithDefaultSourceDefaults{})
 		assert.NoError(t, err)
 		err = mgr.Set(context.Background(), "db.host", "existing_db_host")
 		assert.NoError(t, err)
@@ -376,7 +376,7 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("load both static and struct defaults", func(t *testing.T) {
 		mgr, dcs := setupDefaultConfigTest(t, map[string]any{"app.name": "TestApp"}, "")
-		err := mgr.RegisterStruct("db", testConfigWithDefaults{})
+		err := mgr.RegisterStruct("db", testConfigWithDefaultSourceDefaults{})
 		assert.NoError(t, err)
 
 		err = dcs.Load(ctx, mgr)
@@ -391,7 +391,7 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("order of loading: struct defaults first, then static defaults", func(t *testing.T) {
 		mgr, dcs := setupDefaultConfigTest(t, map[string]any{"conflict.host": "static_host_override"}, "")
-		err := mgr.RegisterStruct("conflict", testConfigWithDefaults{}) // Defaults Host to "default_host"
+		err := mgr.RegisterStruct("conflict", testConfigWithDefaultSourceDefaults{}) // Defaults Host to "default_host"
 		assert.NoError(t, err)
 
 		err = dcs.Load(ctx, mgr)
@@ -405,7 +405,7 @@ func TestDefaultConfigSource_Load(t *testing.T) {
 
 	t.Run("static defaults for a key not in struct defaults", func(t *testing.T) {
 		mgr, dcs := setupDefaultConfigTest(t, map[string]any{"db.user": "static_user"}, "")
-		err := mgr.RegisterStruct("db", testConfigWithDefaults{}) // Defaults host and port
+		err := mgr.RegisterStruct("db", testConfigWithDefaultSourceDefaults{}) // Defaults host and port
 		assert.NoError(t, err)
 
 		err = dcs.Load(ctx, mgr)
@@ -539,7 +539,7 @@ func TestProcessNestedStructs_AllFields(t *testing.T) {
 	}
 
 	// Register the struct with defaults
-	err := mgr.RegisterStruct("test", ParentWithDefaults{})
+	err := mgr.RegisterStruct("test", ParentWithDefaultSourceDefaults{})
 	assert.NoError(t, err)
 
 	// Load the defaults - this internally processes nested structs
@@ -630,12 +630,12 @@ type Nested struct {
 	Child string `config:"child"`
 }
 
-type ParentWithDefaults struct {
+type ParentWithDefaultSourceDefaults struct {
 	Nested1 Nested `config:"nested1"`
 	Nested2 Nested `config:"nested2"`
 }
 
-func (p *ParentWithDefaults) Defaults() map[string]any {
+func (p *ParentWithDefaultSourceDefaults) Defaults() map[string]any {
 	return map[string]any{
 		"Nested1": map[string]any{
 			"Child": "child1",


### PR DESCRIPTION
- Fixed incorrect option function names that were preventing compilation:
  - Changed WithDefaults -> WithDefaultSourceDefaults
  - Changed WithTagName -> WithDefaultSourceTagName
  - Changed WithGlobal -> WithDefaultSourceGlobal
  - Changed WithEnvGlobal -> WithEnvSourceGlobal
- Updated all test cases and related struct names to match new function names