### PR TITLE
fix: prevent panic when RegisterStruct receives nil configuration

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -523,7 +523,14 @@ func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, any, error)
 
 // RegisterStruct registers a configuration struct type for a key at runtime.
 // Returns an error if the key is already registered to a different type.
+// If cfg is a nil interface, this is a no-op.
+// If cfg is a typed nil pointer (e.g., (*MyCfg)(nil)), the underlying value type is registered.
 func (cm *ConfigManagerDefault) RegisterStruct(key string, cfg any) error {
+	if cfg == nil {
+		cm.logger.Debug("RegisterStruct called with nil cfg; no-op", zap.String("key", key))
+		return nil
+	}
+
 	cm.configStructLock.Lock()
 	defer cm.configStructLock.Unlock()
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -317,6 +317,13 @@ func TestConfigManager_All(t *testing.T) {
 }
 
 func TestConfigManager_RegisterStructGet(t *testing.T) {
+	t.Run("nil config returns no error", func(t *testing.T) {
+		cm := newTestManager()
+		err := cm.RegisterStruct("test.nil", nil)
+		assert.NoError(t, err)
+		assert.False(t, cm.hasConfigStruct("test.nil"))
+	})
+
 	t.Run("value registration with pointer target", func(t *testing.T) {
 		cm := newTestManager()
 		// Register the value type
@@ -351,6 +358,17 @@ func TestConfigManager_RegisterStructGet(t *testing.T) {
 		assert.IsType(t, map[string]interface{}{}, raw)
 		assert.IsType(t, &TestConfig{}, decoded)
 		assert.Equal(t, "nil_target", decoded.(*TestConfig).StringValue)
+	})
+
+	t.Run("typed nil pointer registers underlying type", func(t *testing.T) {
+		cm := newTestManager()
+		var p *TestConfig = nil
+		err := cm.RegisterStruct("test.typednil", p)
+		assert.NoError(t, err)
+		assert.True(t, cm.hasConfigStruct("test.typednil"))
+		regs := cm.GetRegisteredStructs()
+		require.Contains(t, regs, "test.typednil")
+		assert.Equal(t, reflect.TypeOf(TestConfig{}), regs["test.typednil"])
 	})
 
 	t.Run("value registration with value target", func(t *testing.T) {


### PR DESCRIPTION
- Added a nil check in RegisterStruct to return early if the provided config is nil
- Added a test case to verify that RegisterStruct handles nil input without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Config registration now safely no-ops when a configuration value is nil, avoiding errors while preserving behavior for valid, non-nil configurations.

* **Tests**
  * Added tests confirming nil and typed-nil registration scenarios behave correctly, preventing regressions and ensuring consistent config handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->