### PR TITLE
feat: add configuration key description management

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,14 @@ type Manager interface {
 	// Flag management
 	FlagManager() FlagManager
 
+	// Description management
+	DescriptionManager() DescriptionManager
+	GetDescription(key string) string
+	GetAllDescriptions() map[string]string
+	GetDescriptionsForPrefix(prefix string) map[string]string
+	SetDescription(key string, description string)
+	SetDescriptions(descriptions map[string]string)
+
 	// Configuration access
 	Get(key string, target ...any) (any, any, error)
 	GetString(key string) (string, error)

--- a/description_manager.go
+++ b/description_manager.go
@@ -1,0 +1,77 @@
+package configmanager
+
+import "sync"
+
+// DescriptionManager manages descriptions associated with configuration keys
+type DescriptionManager interface {
+	// SetDescription sets a description for a configuration key
+	SetDescription(key string, description string)
+	// GetDescription gets a description for a configuration key
+	GetDescription(key string) string
+	// SetDescriptions sets multiple descriptions at once
+	SetDescriptions(descriptions map[string]string)
+	// GetAllDescriptions returns all descriptions
+	GetAllDescriptions() map[string]string
+	// GetDescriptionsForPrefix returns all descriptions matching the given prefix
+	GetDescriptionsForPrefix(prefix string) map[string]string
+}
+
+// DescriptionManagerDefault is the default implementation of DescriptionManager
+type DescriptionManagerDefault struct {
+	descriptions map[string]string
+	mu           sync.RWMutex
+}
+
+// NewDescriptionManager creates a new DescriptionManagerDefault
+func NewDescriptionManager() *DescriptionManagerDefault {
+	return &DescriptionManagerDefault{
+		descriptions: make(map[string]string),
+	}
+}
+
+// SetDescription sets a description for a configuration key
+func (d *DescriptionManagerDefault) SetDescription(key string, description string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.descriptions[key] = description
+}
+
+// GetDescription gets a description for a configuration key
+func (d *DescriptionManagerDefault) GetDescription(key string) string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.descriptions[key]
+}
+
+// SetDescriptions sets multiple descriptions at once
+func (d *DescriptionManagerDefault) SetDescriptions(descriptions map[string]string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for key, desc := range descriptions {
+		d.descriptions[key] = desc
+	}
+}
+
+// GetAllDescriptions returns all descriptions
+func (d *DescriptionManagerDefault) GetAllDescriptions() map[string]string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	result := make(map[string]string, len(d.descriptions))
+	for key, desc := range d.descriptions {
+		result[key] = desc
+	}
+	return result
+}
+
+// GetDescriptionsForPrefix returns all descriptions matching the given prefix
+func (d *DescriptionManagerDefault) GetDescriptionsForPrefix(prefix string) map[string]string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	result := make(map[string]string)
+	for key, desc := range d.descriptions {
+		if prefix == "" || key == prefix || (len(key) > len(prefix) && key[:len(prefix)] == prefix && key[len(prefix)] == '.') {
+			result[key] = desc
+		}
+	}
+	return result
+}

--- a/description_manager_test.go
+++ b/description_manager_test.go
@@ -1,0 +1,470 @@
+package configmanager
+
+import (
+	"sync"
+	"testing"
+)
+
+// Test helpers
+func setupTestManager(t *testing.T, config any) Manager {
+	t.Helper()
+	cm, err := NewConfigManager(
+		UsingSources(),
+		WithConfigStruct("", config),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+	return cm
+}
+
+func assertDescription(t *testing.T, dm DescriptionManager, key, expected string) {
+	t.Helper()
+	if desc := dm.GetDescription(key); desc != expected {
+		t.Errorf("Expected '%s' for key '%s', got '%s'", expected, key, desc)
+	}
+}
+
+// DescriptionManager implementation tests
+func TestNewDescriptionManager(t *testing.T) {
+	dm := NewDescriptionManager()
+	if dm == nil {
+		t.Fatal("NewDescriptionManager returned nil")
+	}
+}
+
+func TestDescriptionManager_SetAndGetDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		desc     string
+		expected string
+	}{
+		{
+			name:     "set and get description",
+			key:      "test.key",
+			desc:     "Test description",
+			expected: "Test description",
+		},
+		{
+			name:     "get non-existent key returns empty string",
+			key:      "nonexistent",
+			desc:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dm := NewDescriptionManager()
+			if tt.desc != "" {
+				dm.SetDescription(tt.key, tt.desc)
+			}
+			assertDescription(t, dm, tt.key, tt.expected)
+		})
+	}
+}
+
+func TestDescriptionManager_SetDescriptions(t *testing.T) {
+	dm := NewDescriptionManager()
+
+	descriptions := map[string]string{
+		"key1": "Description 1",
+		"key2": "Description 2",
+		"key3": "Description 3",
+	}
+
+	dm.SetDescriptions(descriptions)
+
+	for key, expectedDesc := range descriptions {
+		assertDescription(t, dm, key, expectedDesc)
+	}
+}
+
+func TestDescriptionManager_GetAllDescriptions(t *testing.T) {
+	dm := NewDescriptionManager()
+
+	dm.SetDescription("key1", "Description 1")
+	dm.SetDescription("key2", "Description 2")
+
+	all := dm.GetAllDescriptions()
+
+	if len(all) != 2 {
+		t.Errorf("Expected 2 descriptions, got %d", len(all))
+	}
+
+	assertDescription(t, dm, "key1", "Description 1")
+	assertDescription(t, dm, "key2", "Description 2")
+
+	// Verify that modifying the returned map doesn't affect the internal state
+	all["key3"] = "Description 3"
+	if dm.GetDescription("key3") != "" {
+		t.Error("Modifying returned map should not affect internal state")
+	}
+}
+
+func TestDescriptionManager_GetDescriptionsForPrefix(t *testing.T) {
+	dm := NewDescriptionManager()
+
+	dm.SetDescription("database.host", "Database host")
+	dm.SetDescription("database.port", "Database port")
+	dm.SetDescription("database.user", "Database user")
+	dm.SetDescription("app.name", "Application name")
+	dm.SetDescription("app.port", "Application port")
+
+	tests := []struct {
+		name          string
+		prefix        string
+		expectedCount int
+	}{
+		{
+			name:          "prefix matching",
+			prefix:        "database",
+			expectedCount: 3,
+		},
+		{
+			name:          "exact key match",
+			prefix:        "database.host",
+			expectedCount: 1,
+		},
+		{
+			name:          "empty prefix returns all",
+			prefix:        "",
+			expectedCount: 5,
+		},
+		{
+			name:          "non-existent prefix",
+			prefix:        "nonexistent",
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			descs := dm.GetDescriptionsForPrefix(tt.prefix)
+			if len(descs) != tt.expectedCount {
+				t.Errorf("Expected %d descriptions for prefix '%s', got %d", tt.expectedCount, tt.prefix, len(descs))
+			}
+		})
+	}
+}
+
+func TestDescriptionManager_ConcurrentAccess(t *testing.T) {
+	dm := NewDescriptionManager()
+	var wg sync.WaitGroup
+
+	// Test concurrent writes
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := "concurrent.key." + string(rune('a'+n%26))
+			dm.SetDescription(key, "Description "+string(rune('a'+n%26)))
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all writes
+	for i := 0; i < 100; i++ {
+		key := "concurrent.key." + string(rune('a'+i%26))
+		if dm.GetDescription(key) == "" {
+			t.Errorf("Concurrent write failed for key %s", key)
+		}
+	}
+
+	// Test concurrent reads
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := "concurrent.key." + string(rune('a'+n%26))
+			_ = dm.GetDescription(key)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// Struct description extraction tests
+func TestExtractStructDescriptions(t *testing.T) {
+	type NestedConfig struct {
+		Field1 string `config:"field1" desc:"Nested field 1"`
+		Field2 int    `config:"field2" desc:"Nested field 2"`
+	}
+
+	type TestConfig struct {
+		SimpleField string        `config:"simple" desc:"Simple field description"`
+		NumberField int           `config:"number" desc:"Number field description"`
+		Nested      NestedConfig  `config:"nested" desc:"Nested config"`
+		PtrNested   *NestedConfig `config:"ptr_nested" desc:"Pointer to nested config"`
+		NoDesc      string        `config:"no_desc"`
+		unexported  string        `config:"unexported" desc:"This should be ignored"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+	dm := cm.DescriptionManager()
+
+	tests := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{"simple field", "simple", "Simple field description"},
+		{"number field", "number", "Number field description"},
+		{"nested field", "nested.field1", "Nested field 1"},
+		{"pointer to nested field", "ptr_nested.field2", "Nested field 2"},
+		{"field without description", "no_desc", ""},
+		{"unexported field", "unexported", ""},
+		{"nested config description", "nested", "Nested config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertDescription(t, dm, tt.key, tt.expected)
+		})
+	}
+}
+
+// Manager interface description tests
+func TestWithDescriptions(t *testing.T) {
+	descriptions := map[string]string{
+		"manual.key1": "Manual description 1",
+		"manual.key2": "Manual description 2",
+	}
+
+	cm, err := NewConfigManager(
+		UsingSources(),
+		WithDescriptions(descriptions),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	dm := cm.DescriptionManager()
+	assertDescription(t, dm, "manual.key1", "Manual description 1")
+	assertDescription(t, dm, "manual.key2", "Manual description 2")
+}
+
+func TestGetDescription(t *testing.T) {
+	type TestConfig struct {
+		Field string `config:"field" desc:"Field description"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+	assertDescription(t, cm, "field", "Field description")
+	assertDescription(t, cm, "nonexistent", "")
+}
+
+func TestGetAllDescriptions(t *testing.T) {
+	type TestConfig struct {
+		Field1 string `config:"field1" desc:"Description 1"`
+		Field2 string `config:"field2" desc:"Description 2"`
+	}
+
+	cm, err := NewConfigManager(
+		UsingSources(),
+		WithConfigStruct("", TestConfig{}),
+		WithDescriptions(map[string]string{
+			"manual.key": "Manual description",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	all := cm.GetAllDescriptions()
+
+	if len(all) != 3 {
+		t.Errorf("Expected 3 descriptions, got %d", len(all))
+	}
+
+	assertDescription(t, cm, "field1", "Description 1")
+	assertDescription(t, cm, "manual.key", "Manual description")
+}
+
+func TestGetDescriptionsForPrefix(t *testing.T) {
+	type TestConfig struct {
+		DatabaseHost string `config:"database.host" desc:"DB host"`
+		DatabasePort int    `config:"database.port" desc:"DB port"`
+		AppName      string `config:"app.name" desc:"App name"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+
+	tests := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{"database.host description", "database.host", "DB host"},
+		{"database.port description", "database.port", "DB port"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertDescription(t, cm, tt.key, tt.expected)
+		})
+	}
+
+	dbDescs := cm.GetDescriptionsForPrefix("database")
+	if len(dbDescs) != 2 {
+		t.Errorf("Expected 2 descriptions for 'database' prefix, got %d", len(dbDescs))
+	}
+	if dbDescs["database.host"] != "DB host" {
+		t.Errorf("Expected 'DB host', got '%s'", dbDescs["database.host"])
+	}
+}
+
+func TestDescriptionInErrorMessages(t *testing.T) {
+	type TestConfig struct {
+		Field string `config:"field" desc:"This is a test field"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+
+	_, _, err := cm.Get("nonexistent")
+	if err == nil {
+		t.Fatal("Expected error for non-existent key")
+	}
+
+	errMsg := err.Error()
+	if errMsg == "" {
+		t.Fatal("Error message should not be empty")
+	}
+
+	// The error should mention the key
+	if !contains(errMsg, "nonexistent") {
+		t.Errorf("Error message should contain the key name, got: %s", errMsg)
+	}
+}
+
+// Manager SetDescription/SetDescriptions tests
+func TestManager_SetDescription(t *testing.T) {
+	type TestConfig struct {
+		Field string `config:"field" desc:"Original description"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+
+	// Verify initial description from struct tag
+	assertDescription(t, cm, "field", "Original description")
+
+	// Set a new description at runtime
+	cm.SetDescription("field", "Updated description")
+	assertDescription(t, cm, "field", "Updated description")
+
+	// Set description for a new key that wasn't in the struct
+	cm.SetDescription("new.key", "New key description")
+	assertDescription(t, cm, "new.key", "New key description")
+}
+
+func TestManager_SetDescriptions(t *testing.T) {
+	type TestConfig struct {
+		Field1 string `config:"field1" desc:"Original field 1"`
+		Field2 string `config:"field2" desc:"Original field 2"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+
+	// Verify initial descriptions
+	assertDescription(t, cm, "field1", "Original field 1")
+	assertDescription(t, cm, "field2", "Original field 2")
+
+	// Set multiple descriptions at once
+	newDescriptions := map[string]string{
+		"field1":   "Updated field 1",
+		"field2":   "Updated field 2",
+		"new.key1": "New key 1",
+		"new.key2": "New key 2",
+	}
+
+	cm.SetDescriptions(newDescriptions)
+
+	// Verify all descriptions were updated
+	for key, expectedDesc := range newDescriptions {
+		assertDescription(t, cm, key, expectedDesc)
+	}
+
+	// Verify struct descriptions are updated
+	assertDescription(t, cm, "field1", "Updated field 1")
+	assertDescription(t, cm, "field2", "Updated field 2")
+}
+
+func TestManager_SetDescription_WithNamespaces(t *testing.T) {
+	cm := setupTestManager(t, struct{}{})
+
+	// Set descriptions with different namespaces
+	cm.SetDescription("database.host", "Database host")
+	cm.SetDescription("database.port", "Database port")
+	cm.SetDescription("app.name", "Application name")
+
+	// Verify descriptions are accessible
+	assertDescription(t, cm, "database.host", "Database host")
+	assertDescription(t, cm, "database.port", "Database port")
+	assertDescription(t, cm, "app.name", "Application name")
+
+	// Get descriptions by prefix
+	dbDescs := cm.GetDescriptionsForPrefix("database")
+	if len(dbDescs) != 2 {
+		t.Errorf("Expected 2 descriptions for 'database' prefix, got %d", len(dbDescs))
+	}
+	if dbDescs["database.host"] != "Database host" {
+		t.Errorf("Expected 'Database host', got '%s'", dbDescs["database.host"])
+	}
+}
+
+func TestManager_SetDescription_OverwriteStructTag(t *testing.T) {
+	type TestConfig struct {
+		Field string `config:"field" desc:"Struct tag description"`
+	}
+
+	cm := setupTestManager(t, TestConfig{})
+
+	// Verify initial description from struct tag
+	assertDescription(t, cm, "field", "Struct tag description")
+
+	// Overwrite with runtime description
+	cm.SetDescription("field", "Runtime description")
+	assertDescription(t, cm, "field", "Runtime description")
+}
+
+func TestManager_SetDescription_Concurrent(t *testing.T) {
+	cm := setupTestManager(t, struct{}{})
+	var wg sync.WaitGroup
+
+	// Test concurrent SetDescription calls
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := "concurrent.key." + string(rune('a'+n%26))
+			cm.SetDescription(key, "Description "+string(rune('a'+n%26)))
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all descriptions were set
+	dm := cm.DescriptionManager()
+	for i := 0; i < 100; i++ {
+		key := "concurrent.key." + string(rune('a'+i%26))
+		if dm.GetDescription(key) == "" {
+			t.Errorf("Concurrent SetDescription failed for key %s", key)
+		}
+	}
+}
+
+// Helper function for string contains check
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsMiddle(s, substr)))
+}
+
+func containsMiddle(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/manager.go
+++ b/manager.go
@@ -33,44 +33,46 @@ func (cm *ConfigManagerDefault) copy() *ConfigManagerDefault {
 	defer cm.configStructLock.RUnlock()
 
 	return &ConfigManagerDefault{
-		koanf:             kkoanf.New(cm.Delim()),
-		sources:           cm.sources,
-		loadedSources:     make(map[source.ConfigSource]bool), // Fresh map for copy
-		watchedSources:    make(map[source.ConfigSource]bool), // Fresh map for copy
-		logger:            cm.logger,
-		events:            cm.events,
-		flagManager:       cm.flagManager,
-		configStructs:     cm.configStructs,
-		configFile:        cm.configFile,
-		configDir:         cm.configDir,
-		tagName:           cm.tagName,
-		registry:          cm.registry,
-		syncConfigNS:      cm.syncConfigNS,
-		validationEnabled: cm.validationEnabled,
-		delimiter:         cm.delimiter,
+		koanf:              kkoanf.New(cm.Delim()),
+		sources:            cm.sources,
+		loadedSources:      make(map[source.ConfigSource]bool), // Fresh map for copy
+		watchedSources:     make(map[source.ConfigSource]bool), // Fresh map for copy
+		logger:             cm.logger,
+		events:             cm.events,
+		flagManager:        cm.flagManager,
+		descriptionManager: cm.descriptionManager,
+		configStructs:      cm.configStructs,
+		configFile:         cm.configFile,
+		configDir:          cm.configDir,
+		tagName:            cm.tagName,
+		registry:           cm.registry,
+		syncConfigNS:       cm.syncConfigNS,
+		validationEnabled:  cm.validationEnabled,
+		delimiter:          cm.delimiter,
 	}
 }
 
 // ConfigManagerDefault is the central point of interaction for accessing and managing configuration.
 type ConfigManagerDefault struct {
-	syncMgr           csync.Manager
-	koanf             *kkoanf.Koanf
-	sources           []source.ConfigSource
-	loadedSources     map[source.ConfigSource]bool // Track which sources have been loaded
-	watchedSources    map[source.ConfigSource]bool // Track which sources have watchers started
-	logger            *zap.Logger
-	validationEnabled bool
-	validationLock    sync.RWMutex
-	events            event.EventManager[csync.ConfigEvent]
-	flagManager       FlagManager
-	configStructs     map[string]reflect.Type
-	configStructLock  sync.RWMutex
-	configFile        string
-	configDir         string
-	tagName           string
-	registry          ConfigRegistry
-	syncConfigNS      string // Namespace for sync client configuration
-	delimiter         string // Custom delimiter for nested keys
+	syncMgr            csync.Manager
+	koanf              *kkoanf.Koanf
+	sources            []source.ConfigSource
+	loadedSources      map[source.ConfigSource]bool // Track which sources have been loaded
+	watchedSources     map[source.ConfigSource]bool // Track which sources have watchers started
+	logger             *zap.Logger
+	validationEnabled  bool
+	validationLock     sync.RWMutex
+	events             event.EventManager[csync.ConfigEvent]
+	flagManager        FlagManager
+	descriptionManager DescriptionManager
+	configStructs      map[string]reflect.Type
+	configStructLock   sync.RWMutex
+	configFile         string
+	configDir          string
+	tagName            string
+	registry           ConfigRegistry
+	syncConfigNS       string // Namespace for sync client configuration
+	delimiter          string // Custom delimiter for nested keys
 }
 
 // Ensure ConfigManagerDefault implements Manager interface
@@ -304,18 +306,19 @@ func NewConfigManager(sources any, opts ...ConfigOption) (*ConfigManagerDefault,
 	}
 
 	cm := &ConfigManagerDefault{
-		koanf:             k,
-		sources:           configSources,
-		loadedSources:     make(map[source.ConfigSource]bool),
-		watchedSources:    make(map[source.ConfigSource]bool),
-		logger:            zap.NewNop(), // Default no-op logger
-		events:            eventMgr,
-		flagManager:       NewFlagManager(),
-		configStructs:     make(map[string]reflect.Type),
-		tagName:           "config", // Default tag name
-		registry:          NewDefaultConfigRegistry(),
-		syncConfigNS:      "sync.config", // Default sync config namespace
-		validationEnabled: true,          // Validation enabled by default
+		koanf:              k,
+		sources:            configSources,
+		loadedSources:      make(map[source.ConfigSource]bool),
+		watchedSources:     make(map[source.ConfigSource]bool),
+		logger:             zap.NewNop(),
+		events:             eventMgr,
+		flagManager:        NewFlagManager(),
+		descriptionManager: NewDescriptionManager(),
+		configStructs:      make(map[string]reflect.Type),
+		tagName:            "config", // Default tag name
+		registry:           NewDefaultConfigRegistry(),
+		syncConfigNS:       "sync.config", // Default sync config namespace
+		validationEnabled:  true,          // Validation enabled by default
 	}
 
 	for _, opt := range opts {
@@ -534,7 +537,11 @@ func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, any, error)
 
 	// Get raw value first
 	if !cm.koanf.Exists(fullKey) {
-		return nil, nil, fmt.Errorf("configuration key '%s' not found", fullKey)
+		errMsg := fmt.Sprintf("configuration key '%s' not found", fullKey)
+		if desc := cm.descriptionManager.GetDescription(fullKey); desc != "" {
+			errMsg += fmt.Sprintf(" (%s)", desc)
+		}
+		return nil, nil, fmt.Errorf("%s", errMsg)
 	}
 	raw := cm.koanf.Get(fullKey)
 
@@ -582,7 +589,55 @@ func (cm *ConfigManagerDefault) RegisterStruct(key string, cfg any) error {
 	}
 
 	cm.configStructs[key] = typ
+
+	// Extract descriptions from struct tags
+	cm.extractStructDescriptions(key, typ)
+
 	return nil
+}
+
+// extractStructDescriptions extracts descriptions from struct tags and registers them
+func (cm *ConfigManagerDefault) extractStructDescriptions(key string, typ reflect.Type) {
+	// Only process structs
+	if typ.Kind() != reflect.Struct {
+		return
+	}
+
+	// Iterate through struct fields
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get the config tag name
+		tagName := field.Tag.Get(cm.tagName)
+		if tagName == "" {
+			tagName = field.Name
+		}
+
+		// Build the full key path
+		fullKey := tagName
+		if key != "" {
+			fullKey = key + cm.Delim() + tagName
+		}
+
+		// Extract description tag
+		if desc := field.Tag.Get("desc"); desc != "" {
+			cm.descriptionManager.SetDescription(fullKey, desc)
+		}
+
+		// Recursively process nested structs
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		if fieldType.Kind() == reflect.Struct {
+			cm.extractStructDescriptions(fullKey, fieldType)
+		}
+	}
 }
 
 // getIntoStruct decodes configuration into a registered struct type (used by RegisterStruct)
@@ -976,7 +1031,11 @@ func (cm *ConfigManagerDefault) validateConfig(key string) error {
 
 	// First check if the key exists in the configuration
 	if !cm.Exists(key) {
-		return fmt.Errorf("configuration key '%s' not found", key)
+		errMsg := fmt.Sprintf("configuration key '%s' not found", key)
+		if desc := cm.descriptionManager.GetDescription(key); desc != "" {
+			errMsg += fmt.Sprintf(" (%s)", desc)
+		}
+		return fmt.Errorf("%s", errMsg)
 	}
 
 	// Check if we have a registered struct for this key
@@ -1228,6 +1287,36 @@ func (cm *ConfigManagerDefault) implementsConfigDefaults(key string) bool {
 // FlagManager returns the flag manager instance
 func (cm *ConfigManagerDefault) FlagManager() FlagManager {
 	return cm.flagManager
+}
+
+// DescriptionManager returns the description manager instance
+func (cm *ConfigManagerDefault) DescriptionManager() DescriptionManager {
+	return cm.descriptionManager
+}
+
+// GetDescription returns the description for a configuration key
+func (cm *ConfigManagerDefault) GetDescription(key string) string {
+	return cm.descriptionManager.GetDescription(key)
+}
+
+// GetAllDescriptions returns all configuration descriptions
+func (cm *ConfigManagerDefault) GetAllDescriptions() map[string]string {
+	return cm.descriptionManager.GetAllDescriptions()
+}
+
+// GetDescriptionsForPrefix returns all descriptions matching the given prefix
+func (cm *ConfigManagerDefault) GetDescriptionsForPrefix(prefix string) map[string]string {
+	return cm.descriptionManager.GetDescriptionsForPrefix(prefix)
+}
+
+// SetDescription sets a description for a configuration key at runtime
+func (cm *ConfigManagerDefault) SetDescription(key string, description string) {
+	cm.descriptionManager.SetDescription(key, description)
+}
+
+// SetDescriptions sets multiple descriptions at once
+func (cm *ConfigManagerDefault) SetDescriptions(descriptions map[string]string) {
+	cm.descriptionManager.SetDescriptions(descriptions)
 }
 
 // GetRegisteredStructs returns a copy of the registered config structs

--- a/options.go
+++ b/options.go
@@ -32,6 +32,14 @@ func WithFlags(flags map[string][]string) ConfigOption {
 	}
 }
 
+// WithDescriptions is a ConfigOption that sets descriptions for configuration keys
+func WithDescriptions(descriptions map[string]string) ConfigOption {
+	return func(cm *ConfigManagerDefault) error {
+		cm.descriptionManager.SetDescriptions(descriptions)
+		return nil
+	}
+}
+
 // WithLogger configures the logger for the ConfigManagerDefault
 func WithLogger(logger *zap.Logger) ConfigOption {
 	return func(cm *ConfigManagerDefault) error {


### PR DESCRIPTION
Add DescriptionManager to manage human-readable descriptions for configuration keys:

- Extract descriptions from struct tags using `desc:"..."` tag
- Set descriptions at initialization via `WithDescriptions()` option
- Set descriptions at runtime via `SetDescription()` and `SetDescriptions()`
- Retrieve descriptions via `GetDescription()`, `GetAllDescriptions()`, and `GetDescriptionsForPrefix()`
- Include descriptions in error messages when configuration keys are not found
- Thread-safe implementation with concurrent access support


---

<!-- kody-pr-summary:start -->
This pull request introduces a new feature for managing descriptions associated with configuration keys.

Key changes include:

*   **Description Management Interface**: A new `DescriptionManager` interface and its default implementation (`DescriptionManagerDefault`) are added, providing methods to set, get, and retrieve descriptions for configuration keys, including fetching all descriptions or those matching a specific prefix. This manager is thread-safe.
*   **Integration with `ConfigManager`**: The main `Manager` interface and `ConfigManagerDefault` now include a `DescriptionManager` and expose its functionalities directly.
*   **Automatic Description Extraction**: When configuration structs are registered using `RegisterStruct`, descriptions can now be automatically extracted from `desc` struct tags (e.g., ``config:"field" desc:"Field description"``). This extraction supports nested structs and pointer fields.
*   **Enhanced Error Messages**: Error messages for non-existent configuration keys now include the associated description if one is available, providing more context.
*   **Runtime Description Updates**: Descriptions can be set or updated at runtime for any configuration key.
*   **Initialization Option**: A new `WithDescriptions` option allows for providing an initial set of configuration key descriptions when creating a `ConfigManager`.
<!-- kody-pr-summary:end -->