### PR TITLE
feat: add ROOT_NS constant and lookup logic

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -23,6 +23,7 @@ import (
 const (
 	schemaValidationRootPath = "$root"
 	keySeparator             = "."
+	ROOT_NS                  = ""
 )
 
 // copy creates a throwaway copy of the ConfigManagerDefault with a new Koanf instance.
@@ -1347,6 +1348,12 @@ func (cm *ConfigManagerDefault) GetRegisteredStructs() map[string]reflect.Type {
 // findNearestStructKey finds the nearest parent key that has a registered struct
 func (cm *ConfigManagerDefault) findNearestStructKey(key string) string {
 	parts := strings.Split(key, keySeparator)
+	
+	// If there's only one part (no delimiter), check for a root namespace struct
+	if len(parts) == 1 && cm.hasConfigStruct(ROOT_NS) {
+		return ROOT_NS
+	}
+	
 	for i := len(parts); i > 0; i-- {
 		potentialKey := strings.Join(parts[:i], keySeparator)
 		if cm.hasConfigStruct(potentialKey) {
@@ -1382,8 +1389,8 @@ func (cm *ConfigManagerDefault) Delete(key string) {
 
 // Delim returns the delimiter used for nested keys
 func (cm *ConfigManagerDefault) Root(target any) (any, error) {
-	if !cm.hasConfigStruct("") {
-		return nil, fmt.Errorf("no root configuration struct registered - use RegisterStruct(\"\", yourStruct{})")
+	if !cm.hasConfigStruct(ROOT_NS) {
+		return nil, fmt.Errorf("no root configuration struct registered - use RegisterStruct(ROOT_NS, yourStruct{})")
 	}
 	return cm.getIntoStruct("", target)
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -3,6 +3,8 @@ package configmanager
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"github.com/Oudwins/zog"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
@@ -2411,5 +2413,119 @@ func TestConfigManager_BulkSetAtomicInternal(t *testing.T) {
 		err = cm.bulkSetAtomicInternal(context.Background(), updates, true)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, notifyCount)
+	})
+}
+
+func TestConfigManager_RootNamespacePersist(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Define a simple config struct for testing
+	type AppConfig struct {
+		Name     string `config:"name"`
+		Port     int    `config:"port"`
+		Enabled  bool   `config:"enabled"`
+	}
+
+	// First manager: Create, set values, and persist
+	t.Run("save config", func(t *testing.T) {
+		cm, err := NewConfigManager([]source.ConfigSource{})
+		require.NoError(t, err)
+
+		// Register file source with root namespace
+		fileSource := source.NewFileSource(configFile)
+		cm.RegisterSource(fileSource)
+		cm.RegisterNamespace(ROOT_NS, fileSource)
+
+		// Register config struct for root namespace
+		err = cm.RegisterStruct(ROOT_NS, &AppConfig{})
+		require.NoError(t, err)
+
+		// Set some values
+		err = cm.Set(context.Background(), "name", "test-app")
+		require.NoError(t, err)
+		err = cm.Set(context.Background(), "port", 8080)
+		require.NoError(t, err)
+		err = cm.Set(context.Background(), "enabled", true)
+		require.NoError(t, err)
+
+		// Verify values are set
+		val, _, err := cm.Get("name")
+		require.NoError(t, err)
+		assert.Equal(t, "test-app", val)
+
+		// Persist to file
+		err = cm.Persist()
+		require.NoError(t, err)
+
+		// Verify file exists
+		_, err = os.Stat(configFile)
+		require.NoError(t, err)
+	})
+
+	// Second manager: Load from file and verify values
+	t.Run("load config", func(t *testing.T) {
+		cm, err := NewConfigManager([]source.ConfigSource{})
+		require.NoError(t, err)
+
+		// Register file source with root namespace
+		fileSource := source.NewFileSource(configFile)
+		cm.RegisterSource(fileSource)
+		cm.RegisterNamespace(ROOT_NS, fileSource)
+
+		// Register config struct for root namespace
+		err = cm.RegisterStruct(ROOT_NS, &AppConfig{})
+		require.NoError(t, err)
+
+		// Load from file
+		err = cm.Load()
+		require.NoError(t, err)
+
+		// Verify loaded values
+		val, _, err := cm.Get("name")
+		require.NoError(t, err)
+		assert.Equal(t, "test-app", val)
+
+		val, _, err = cm.Get("port")
+		require.NoError(t, err)
+		assert.Equal(t, 8080, val)
+
+		val, _, err = cm.Get("enabled")
+		require.NoError(t, err)
+		assert.Equal(t, true, val)
+
+		// Verify findNearestStructKey returns ROOT_NS for single-part keys
+		structKey := cm.findNearestStructKey("name")
+		assert.Equal(t, ROOT_NS, structKey)
+
+		structKey = cm.findNearestStructKey("port")
+		assert.Equal(t, ROOT_NS, structKey)
+
+		structKey = cm.findNearestStructKey("enabled")
+		assert.Equal(t, ROOT_NS, structKey)
+	})
+
+	// Test validation with root namespace
+	t.Run("validate root namespace config", func(t *testing.T) {
+		cm, err := NewConfigManager([]source.ConfigSource{})
+		require.NoError(t, err)
+
+		// Register file source with root namespace
+		fileSource := source.NewFileSource(configFile)
+		cm.RegisterSource(fileSource)
+		cm.RegisterNamespace(ROOT_NS, fileSource)
+
+		// Register config struct for root namespace
+		err = cm.RegisterStruct(ROOT_NS, &AppConfig{})
+		require.NoError(t, err)
+
+		// Load from file
+		err = cm.Load()
+		require.NoError(t, err)
+
+		// Validate the entire config
+		err = cm.Validate()
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces support for a root namespace configuration in the config manager. The changes add a new `ROOT_NS` constant (empty string) and implement logic to handle configuration at the root level.

Key changes include:
- Added `ROOT_NS` constant to represent the root namespace
- Modified `findNearestStructKey` to check for root namespace structs when keys have no delimiter
- Updated error messages in the `Root` method to use the new constant
- Added comprehensive tests demonstrating root namespace functionality including persistence, loading, and validation

The implementation allows registering configuration structs at the root level, enabling flat configuration structures without requiring nested keys or namespaces.
<!-- kody-pr-summary:end -->