### PR TITLE
fix: decouple config loading from file watcher startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,7 +25,9 @@ type SubscriptionCallback func(pattern, key string, value any)
 type Manager interface {
 	// Core operations
 	Load() error
+	LoadWithoutWatch() error
 	LoadAll() error
+	StartWatching()
 	Shutdown() error
 	Validate(keyPrefix ...string) error
 	Persist(keyPrefix ...string) error

--- a/manager.go
+++ b/manager.go
@@ -408,8 +408,12 @@ func (cm *ConfigManagerDefault) loadSource(src source.ConfigSource) error {
 
 // loadSources is the common implementation for loading sources.
 // If onlyNew is true, only sources that haven't been loaded before will be processed.
-// If onlyNew is false, all sources will be processed.
-func (cm *ConfigManagerDefault) loadSources(onlyNew bool) error {
+// loadSources is the common implementation for loading sources. If watch is
+// true, each source is also watched after loading (the default behavior).
+// When watch is false, only loading is performed — callers must start
+// watching separately (e.g. via StartWatching or LoadSource with watch=true)
+// if they need live config change notifications.
+func (cm *ConfigManagerDefault) loadSources(onlyNew bool, watch bool) error {
 	// Disable validation during initial load to avoid validation errors
 	// from partially loaded configurations
 	cm.DisableValidation()
@@ -428,18 +432,8 @@ func (cm *ConfigManagerDefault) loadSources(onlyNew bool) error {
 		// Mark this source as loaded
 		cm.loadedSources[src] = true
 
-		// Start watching if supported and not already watching
-		if !cm.watchedSources[src] {
-			if err := src.Watch(context.Background(), cm, func(changedKeys []string, err error) {
-				cm.handleConfigChanges(src, changedKeys)
-			}); err != nil {
-				cm.logger.Warn("failed to start config watcher",
-					zap.String("source", fmt.Sprintf("%T", src)),
-					zap.Error(err))
-			} else {
-				// Mark as watched only if Watch() succeeded
-				cm.watchedSources[src] = true
-			}
+		if watch {
+			cm.startWatching(src)
 		}
 	}
 
@@ -451,16 +445,53 @@ func (cm *ConfigManagerDefault) loadSources(onlyNew bool) error {
 	return nil
 }
 
-// Load loads configuration from only new sources that haven't been loaded before.
-// This method is atomic and will not reload sources that have already been processed.
-func (cm *ConfigManagerDefault) Load() error {
-	return cm.loadSources(true)
+// startWatching starts watching a source if it isn't already watched.
+// Watch errors are logged as warnings and do not fail the operation.
+func (cm *ConfigManagerDefault) startWatching(src source.ConfigSource) {
+	if cm.watchedSources[src] {
+		return
+	}
+	if err := src.Watch(context.Background(), cm, func(changedKeys []string, err error) {
+		cm.handleConfigChanges(src, changedKeys)
+	}); err != nil {
+		cm.logger.Warn("failed to start config watcher",
+			zap.String("source", fmt.Sprintf("%T", src)),
+			zap.Error(err))
+		return
+	}
+	cm.watchedSources[src] = true
 }
 
-// LoadAll loads configuration from all configured sources, processing everything again.
+// StartWatching starts watching all registered sources that have been loaded
+// but not yet watched. This is useful when sources were loaded without
+// watching (e.g. via LoadWithoutWatch) and the caller wants to activate
+// change notifications after initialization is complete.
+func (cm *ConfigManagerDefault) StartWatching() {
+	for _, src := range cm.sources {
+		cm.startWatching(src)
+	}
+}
+
+// Load loads configuration from only new sources that haven't been loaded before.
+// This method is atomic and will not reload sources that have already been processed.
+// Sources are also watched for changes after loading.
+func (cm *ConfigManagerDefault) Load() error {
+	return cm.loadSources(true, true)
+}
+
+// LoadWithoutWatch loads configuration from only new sources without starting
+// file watchers. Call StartWatching() after initialization is complete to
+// activate change notifications. This prevents spurious config change events
+// from writes that happen during initialization (e.g. persisting defaults).
+func (cm *ConfigManagerDefault) LoadWithoutWatch() error {
+	return cm.loadSources(true, false)
+}
+
+// LoadAll loads configuration from all sources, processing everything again.
 // This method reloads all sources regardless of whether they were loaded before.
+// Sources are also watched for changes after loading.
 func (cm *ConfigManagerDefault) LoadAll() error {
-	return cm.loadSources(false)
+	return cm.loadSources(false, true)
 }
 
 // GetString returns the string value for the given key.
@@ -1369,12 +1400,12 @@ func (cm *ConfigManagerDefault) GetRegisteredStructs() map[string]reflect.Type {
 // findNearestStructKey finds the nearest parent key that has a registered struct
 func (cm *ConfigManagerDefault) findNearestStructKey(key string) string {
 	parts := strings.Split(key, keySeparator)
-	
+
 	// If there's only one part (no delimiter), check for a root namespace struct
 	if len(parts) == 1 && cm.hasConfigStruct(ROOT_NS) {
 		return ROOT_NS
 	}
-	
+
 	for i := len(parts); i > 0; i-- {
 		potentialKey := strings.Join(parts[:i], keySeparator)
 		if cm.hasConfigStruct(potentialKey) {

--- a/manager_test.go
+++ b/manager_test.go
@@ -3,11 +3,11 @@ package configmanager
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"github.com/Oudwins/zog"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -837,6 +837,37 @@ func TestConfigManager_implementsInterface(t *testing.T) {
 
 	validatorType := reflect.TypeOf((*Validator)(nil)).Elem()
 	assert.False(t, cm.implementsInterface("test", validatorType))
+}
+
+func TestConfigManager_LoadWithoutWatch(t *testing.T) {
+	// Use a file source so we can test that LoadWithoutWatch does not start
+	// the fsnotify watcher.
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("key: value\n"), 0644))
+
+	fileSrc := source.NewFileSource(configFile)
+	cm, err := NewConfigManager([]source.ConfigSource{fileSrc}, WithLogger(zap.NewNop()))
+	require.NoError(t, err)
+
+	// LoadWithoutWatch should load without starting watchers
+	require.NoError(t, cm.LoadWithoutWatch())
+
+	// Value should be loaded
+	val, _, err := cm.Get("key")
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+
+	// No source should be marked as watched
+	for _, src := range cm.sources {
+		assert.False(t, cm.watchedSources[src], "source should not be watched after LoadWithoutWatch")
+	}
+
+	// StartWatching should activate watchers
+	cm.StartWatching()
+	for _, src := range cm.sources {
+		assert.True(t, cm.watchedSources[src], "source should be watched after StartWatching")
+	}
 }
 
 func TestConfigManager_DeleteNotifiesWatchers(t *testing.T) {
@@ -2423,9 +2454,9 @@ func TestConfigManager_RootNamespacePersist(t *testing.T) {
 
 	// Define a simple config struct for testing
 	type AppConfig struct {
-		Name     string `config:"name"`
-		Port     int    `config:"port"`
-		Enabled  bool   `config:"enabled"`
+		Name    string `config:"name"`
+		Port    int    `config:"port"`
+		Enabled bool   `config:"enabled"`
 	}
 
 	// First manager: Create, set values, and persist


### PR DESCRIPTION
## Summary
- Add `LoadWithoutWatch()` and `StartWatching()` to the `Manager` interface
- `loadSources()` now accepts a `watch` parameter; `Load()` and `LoadAll()` still watch by default (backward compatible)
- Extracted `startWatching()` helper to avoid duplicating watcher setup logic
- Added `TestConfigManager_LoadWithoutWatch` to verify loading without watchers and subsequent `StartWatching()` activation

`loadSources()` previously started fsnotify watchers for each source immediately after loading. When callers write to config files during initialization (e.g. persisting defaults after `Load()`), the watcher fires asynchronously, triggering config change notifications that invalidate cached state. This caused flaky tests where `assert.Same` (pointer equality) failed because `invalidateConfig` was called between two `Config()` calls by the async watcher goroutine.

---

<!-- kody-pr-summary:start -->
This PR decouples configuration loading from file watcher startup, allowing sources to be loaded without immediately activating change notifications.

**Key changes:**
- Adds `LoadWithoutWatch()` to the `Manager` interface, which loads configuration from new sources without starting file watchers
- Adds `StartWatching()` to the interface, which activates watchers for all loaded sources on demand
- Refactors the internal `loadSources` method to accept a `watch` boolean parameter, extracting watcher startup logic into a dedicated `startWatching` helper
- `Load()` and `LoadAll()` retain their existing behavior of loading and watching simultaneously
- Adds a test verifying that `LoadWithoutWatch` loads values without marking sources as watched, and that `StartWatching` subsequently activates watchers

This prevents spurious config change events that can occur during initialization (e.g., when persisting defaults triggers file writes) by allowing callers to complete initialization before enabling live change notifications.
<!-- kody-pr-summary:end -->