### PR TITLE
fix: resolve flaky TestFileSource_Watch with proper fsnotify lifecycle

### DIFF
--- a/source/file.go
+++ b/source/file.go
@@ -192,14 +192,7 @@ func (f *fileSource) Watch(ctx context.Context, cm configManager, cb WatchOnChan
 
 				// File was removed.
 				if event.Op&fsnotify.Remove != 0 {
-					f.watcherLock.Lock()
-					if f.debounceTimer != nil {
-						if f.debounceTimer.Stop() {
-							f.processWg.Done()
-						}
-						f.debounceTimer = nil
-					}
-					f.watcherLock.Unlock()
+					f.stopDebounce()
 					cb(AllChanges, fmt.Errorf("file %s was removed", event.Name))
 					return
 				}
@@ -207,6 +200,7 @@ func (f *fileSource) Watch(ctx context.Context, cm configManager, cb WatchOnChan
 				// Resolve symlink in case the target changed.
 				curPath, err := filepath.EvalSymlinks(f.path)
 				if err != nil {
+					f.stopDebounce()
 					cb(nil, err)
 					return
 				}
@@ -238,14 +232,7 @@ func (f *fileSource) Watch(ctx context.Context, cm configManager, cb WatchOnChan
 				if !ok {
 					return
 				}
-				f.watcherLock.Lock()
-				if f.debounceTimer != nil {
-					if f.debounceTimer.Stop() {
-						f.processWg.Done()
-					}
-					f.debounceTimer = nil
-				}
-				f.watcherLock.Unlock()
+				f.stopDebounce()
 				cb(nil, err)
 				return
 			}
@@ -255,22 +242,37 @@ func (f *fileSource) Watch(ctx context.Context, cm configManager, cb WatchOnChan
 	return nil
 }
 
+// stopDebounce stops the pending debounce timer and waits for any
+// in-flight processFile to complete, ensuring no concurrent cb()
+// invocations. Called from the watcher goroutine on Remove, Error,
+// and EvalSymlinks-failure paths before invoking cb() directly.
+func (f *fileSource) stopDebounce() {
+	f.watcherLock.Lock()
+	var pending bool
+	if f.debounceTimer != nil {
+		if f.debounceTimer.Stop() {
+			f.processWg.Done()
+		} else {
+			pending = true // processFile already fired or is running
+		}
+		f.debounceTimer = nil
+	}
+	f.watcherLock.Unlock()
+	if pending {
+		f.processWg.Wait()
+	}
+}
+
 func (f *fileSource) Stop() error {
 	f.watcherLock.Lock()
 	if f.watcher == nil {
 		f.watcherLock.Unlock()
 		return nil
 	}
-	// Stop any pending debounce timer first to prevent
-	// processFile from running during shutdown.
-	if f.debounceTimer != nil {
-		if f.debounceTimer.Stop() {
-			f.processWg.Done()
-		}
-		f.debounceTimer = nil
-	}
 	watcher := f.watcher
 	f.watcherLock.Unlock()
+
+	f.stopDebounce()
 
 	err := watcher.Close()
 	<-f.watcherDone
@@ -278,18 +280,11 @@ func (f *fileSource) Stop() error {
 	// Re-stop any timer the goroutine may have created between the
 	// unlock above and its exit; the goroutine cannot create any more
 	// timers once watcherDone is closed.
+	f.stopDebounce()
+
 	f.watcherLock.Lock()
-	if f.debounceTimer != nil {
-		if f.debounceTimer.Stop() {
-			f.processWg.Done()
-		}
-		f.debounceTimer = nil
-	}
 	f.watcher = nil
 	f.watcherLock.Unlock()
-
-	// Wait for any in-flight processFile to complete.
-	f.processWg.Wait()
 
 	return err
 }

--- a/source/file.go
+++ b/source/file.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"sync"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
@@ -23,6 +25,11 @@ type fileSource struct {
 	changedThreshold float64 // Percentage (0-1) of keys that must change to trigger full reload
 	logger           *zap.Logger
 	initialLoad      bool // Track if this is the first load
+	watcher          *fsnotify.Watcher
+	watcherDone      chan struct{}
+	debounceTimer    *time.Timer
+	watcherLock      sync.Mutex // Protects watcher, watcherDone, debounceTimer
+	processWg        sync.WaitGroup // Tracks in-flight processFile invocations
 }
 
 type FileSourceOption func(*fileSource)
@@ -100,51 +107,191 @@ func (f *fileSource) Load(ctx context.Context, cm configManager) error {
 }
 
 func (f *fileSource) Watch(ctx context.Context, cm configManager, cb WatchOnChangeCallback) error {
-	return f.provider.Watch(func(event any, err error) {
-		if err != nil {
-			// if err is not nil, it means the file was removed
-			cb(AllChanges, err)
-			return
-		}
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
 
-		// Create temporary koanf to load new values
-		tmpKoanf := koanf.New(".")
+	realPath, err := filepath.EvalSymlinks(f.path)
+	if err != nil {
+		w.Close()
+		return err
+	}
+	realPath = filepath.Clean(realPath)
 
-		// Let koanf handle the reading and parsing
-		if err := tmpKoanf.Load(f.provider, yaml.Parser()); err != nil {
-			cb(nil, err)
-			return
-		}
+	// Watch the parent directory to catch create/remove/rename events.
+	fDir := filepath.Dir(f.path)
+	if err := w.Add(fDir); err != nil {
+		w.Close()
+		return err
+	}
 
-		// Compare with previous state
-		f.prevLock.Lock()
-		changedKeys := f.detectChangedKeys(f.prevState, tmpKoanf.All())
-		f.prevState = tmpKoanf.All()
-		f.prevLock.Unlock()
+	f.watcher = w
+	f.watcherDone = make(chan struct{})
 
-		if len(changedKeys) == 0 {
-			cb(nil, nil)
-			return
-		}
+	go func() {
+		defer close(f.watcherDone)
+		var (
+			lastEvent     string
+			lastEventTime time.Time
+		)
 
-		// Update config manager with changed values
-		for _, key := range changedKeys {
-			if tmpKoanf.Exists(key) {
-				if err := cm.Set(ctx, key, tmpKoanf.Get(key)); err != nil {
-					cb(nil, err)
-					return
-				}
-			} else {
-				// Handle deleted keys by setting nil
-				if err := cm.Set(ctx, key, nil); err != nil {
-					cb(nil, err)
-					return
+		processFile := func() {
+			defer f.processWg.Done()
+			tmpKoanf := koanf.New(".")
+			if err := tmpKoanf.Load(f.provider, yaml.Parser()); err != nil {
+				cb(nil, err)
+				return
+			}
+
+			f.prevLock.Lock()
+			changedKeys := f.detectChangedKeys(f.prevState, tmpKoanf.All())
+			f.prevState = tmpKoanf.All()
+			f.prevLock.Unlock()
+
+			if len(changedKeys) == 0 {
+				cb(nil, nil)
+				return
+			}
+
+			for _, key := range changedKeys {
+				if tmpKoanf.Exists(key) {
+					if err := cm.Set(ctx, key, tmpKoanf.Get(key)); err != nil {
+						cb(nil, err)
+						return
+					}
+				} else {
+					if err := cm.Set(ctx, key, nil); err != nil {
+						cb(nil, err)
+						return
+					}
 				}
 			}
+
+			cb(changedKeys, nil)
 		}
 
-		cb(changedKeys, nil)
-	})
+		for {
+			select {
+			case event, ok := <-w.Events:
+				if !ok {
+					return
+				}
+
+				// Debounce duplicate events (some platforms fire multiple times).
+				if event.String() == lastEvent && time.Since(lastEventTime) < 5*time.Millisecond {
+					continue
+				}
+				lastEvent = event.String()
+				lastEventTime = time.Now()
+
+				evFile := filepath.Clean(event.Name)
+				if evFile != realPath && evFile != f.path {
+					continue
+				}
+
+				// File was removed.
+				if event.Op&fsnotify.Remove != 0 {
+					f.watcherLock.Lock()
+					if f.debounceTimer != nil {
+						if f.debounceTimer.Stop() {
+							f.processWg.Done()
+						}
+						f.debounceTimer = nil
+					}
+					f.watcherLock.Unlock()
+					cb(AllChanges, fmt.Errorf("file %s was removed", event.Name))
+					return
+				}
+
+				// Resolve symlink in case the target changed.
+				curPath, err := filepath.EvalSymlinks(f.path)
+				if err != nil {
+					cb(nil, err)
+					return
+				}
+				realPath = filepath.Clean(curPath)
+
+				// Only care about write and create events.
+				if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+					continue
+				}
+
+				// Debounce: wait 50ms for events to settle before processing.
+				// os.WriteFile can trigger multiple fsnotify events; reading
+				// during a partial write produces incorrect diff results.
+				f.watcherLock.Lock()
+				if f.debounceTimer != nil {
+					// Stop the previous timer. If Stop returns true the func
+					// hasn't fired yet, so undo the Add(1) to keep the
+					// WaitGroup balanced. If false, processFile already ran
+					// (or is running) and will call Done itself.
+					if f.debounceTimer.Stop() {
+						f.processWg.Done()
+					}
+				}
+				f.processWg.Add(1)
+				f.debounceTimer = time.AfterFunc(50*time.Millisecond, processFile)
+				f.watcherLock.Unlock()
+
+			case err, ok := <-w.Errors:
+				if !ok {
+					return
+				}
+				f.watcherLock.Lock()
+				if f.debounceTimer != nil {
+					if f.debounceTimer.Stop() {
+						f.processWg.Done()
+					}
+					f.debounceTimer = nil
+				}
+				f.watcherLock.Unlock()
+				cb(nil, err)
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (f *fileSource) Stop() error {
+	f.watcherLock.Lock()
+	if f.watcher == nil {
+		f.watcherLock.Unlock()
+		return nil
+	}
+	// Stop any pending debounce timer first to prevent
+	// processFile from running during shutdown.
+	if f.debounceTimer != nil {
+		if f.debounceTimer.Stop() {
+			f.processWg.Done()
+		}
+		f.debounceTimer = nil
+	}
+	watcher := f.watcher
+	f.watcherLock.Unlock()
+
+	err := watcher.Close()
+	<-f.watcherDone
+
+	// Re-stop any timer the goroutine may have created between the
+	// unlock above and its exit; the goroutine cannot create any more
+	// timers once watcherDone is closed.
+	f.watcherLock.Lock()
+	if f.debounceTimer != nil {
+		if f.debounceTimer.Stop() {
+			f.processWg.Done()
+		}
+		f.debounceTimer = nil
+	}
+	f.watcher = nil
+	f.watcherLock.Unlock()
+
+	// Wait for any in-flight processFile to complete.
+	f.processWg.Wait()
+
+	return err
 }
 
 func (f *fileSource) detectChangedKeys(oldState, newState map[string]any) []string {

--- a/source/file.go
+++ b/source/file.go
@@ -286,6 +286,10 @@ func (f *fileSource) Stop() error {
 	f.watcher = nil
 	f.watcherLock.Unlock()
 
+	// Guarantee no processFile outlives Stop(), even if a previously
+	// replaced timer's processFile is still running.
+	f.processWg.Wait()
+
 	return err
 }
 

--- a/source/file_test.go
+++ b/source/file_test.go
@@ -104,7 +104,7 @@ test.key3: initial
 			assert.Equal(t, "updated", val1)
 			assert.Equal(t, "initial", val2)
 			assert.Equal(t, "initial", val3)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -138,7 +138,7 @@ test.key3: initial
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, AllChanges, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for delete notification")
 		}
 	})
@@ -181,7 +181,7 @@ key5: v5
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, AllChanges, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -224,7 +224,7 @@ key4: v4
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, []string{"key1"}, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -259,7 +259,7 @@ key2: v2
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, []string{"key2"}, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -295,7 +295,7 @@ key2: v2
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, []string{"key2"}, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -331,7 +331,7 @@ key2: v2
 		select {
 		case keys := <-changeChan:
 			assert.Equal(t, AllChanges, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -364,7 +364,7 @@ key2: v2
 		select {
 		case keys := <-changeChan:
 			assert.Nil(t, keys)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for change notification")
 		}
 	})
@@ -395,7 +395,7 @@ key2: v2
 		select {
 		case err := <-errChan:
 			assert.Error(t, err)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for error notification")
 		}
 	})
@@ -425,7 +425,7 @@ key2: v2
 		select {
 		case err := <-errChan:
 			assert.Error(t, err)
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for error notification")
 		}
 	})


### PR DESCRIPTION
## Problem

`TestFileSource_Watch` was flaky — failing intermittently on CI and locally, with different subtests failing each run.

## Root Cause

1. **No watcher cleanup** — `fileSource.Watch()` delegated to koanf's `File.Watch()`, which creates an fsnotify watcher internally with no `Close()` method. Each subtest spawned a watcher goroutine that was never cleaned up. The orphaned watchers all watched `/tmp` and competed for events.

2. **Partial file reads** — `os.WriteFile` triggers multiple fsnotify events on Linux. The watcher read the file on the first event, catching a partial write — making all keys appear `changed` (triggering `AllChanges` instead of the specific key diff).

3. **`filepath.Split` bug** — returns empty dir string for bare filenames like `config.yaml`, causing `w.Add("")` to fail with ENOENT.

## Fix

- Replace koanf's `File.Watch()` with our own `fsnotify.Watcher` for full lifecycle control
- Implement `Stop()` to close watcher, stop debounce timer, and wait for in-flight `processFile`
- 50ms debounce timer to coalesce multiple events from a single `WriteFile`
- `filepath.Dir` instead of `filepath.Split` (normalizes bare filenames to `.`)
- `watcherLock` mutex protects `debounceTimer` from data race
- `sync.WaitGroup` tracks `processFile` invocations; `Stop()` waits before returning
- Re-stop timer after `<-f.watcherDone` to close the goroutine-exit race window
- Check `timer.Stop()` return value to balance WaitGroup `Add/Done`
- Bump test timeouts 2s → 5s for debounce latency

## Verification

`go test ./source/... -run TestFileSource_Watch -race -count=100` — zero failures, zero data races.

---

<!-- kody-pr-summary:start -->
This pull request replaces the file source's reliance on the koanf provider's built-in watch mechanism with a custom `fsnotify`-based file watcher, fixing flaky behavior in `TestFileSource_Watch`.

Key changes:
- Introduces a dedicated `fsnotify` watcher that monitors the file's parent directory to reliably catch write, create, remove, and rename events.
- Adds event debouncing (50ms) to handle multiple filesystem events triggered by a single write, preventing partial reads and incorrect diff results.
- Adds a new `Stop` method that cleanly closes the watcher, cancels pending debounce timers, and waits for any in-flight file processing to complete, ensuring proper lifecycle management and avoiding race conditions during shutdown.
- Increases test timeouts from 2 seconds to 5 seconds to reduce flakiness when waiting for change notifications.
<!-- kody-pr-summary:end -->