### PR TITLE
feat: add ErrKeyNotFound sentinel and OK getter variants

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,12 +47,18 @@ type Manager interface {
 	// Configuration access
 	Get(key string, target ...any) (any, any, error)
 	GetString(key string) (string, error)
+	GetStringOK(key string) (string, bool)
 	GetInt(key string) (int64, error)
+	GetIntOK(key string) (int64, bool)
 	GetBool(key string) (bool, error)
+	GetBoolOK(key string) (bool, bool)
 	GetDuration(key string) (time.Duration, error)
+	GetDurationOK(key string) (time.Duration, bool)
 	GetStringSlice(key string) ([]string, error)
+	GetStringSliceOK(key string) ([]string, bool)
 	All() map[string]any
 	IsSet(ctx context.Context, key string) bool
+	IsSetOK(key string) bool
 	Exists(key string) bool
 
 	// Configuration modification

--- a/manager.go
+++ b/manager.go
@@ -481,9 +481,6 @@ func (cm *ConfigManagerDefault) GetString(key string) (string, error) {
 // GetStringOK returns the string value for the given key and whether the key
 // was set. A present-but-empty value returns ("", true), not ("", false).
 func (cm *ConfigManagerDefault) GetStringOK(key string) (string, bool) {
-	if !cm.Exists(key) {
-		return "", false
-	}
 	val, _, err := cm.Get(key)
 	if err != nil {
 		return "", false
@@ -503,9 +500,6 @@ func (cm *ConfigManagerDefault) GetInt(key string) (int64, error) {
 // GetIntOK returns the int64 value for the given key and whether the key was
 // set. A present-but-invalid value returns (0, false).
 func (cm *ConfigManagerDefault) GetIntOK(key string) (int64, bool) {
-	if !cm.Exists(key) {
-		return 0, false
-	}
 	val, _, err := cm.Get(key)
 	if err != nil {
 		return 0, false
@@ -529,9 +523,6 @@ func (cm *ConfigManagerDefault) GetBool(key string) (bool, error) {
 // GetBoolOK returns the bool value for the given key and whether the key was
 // set. A present-but-invalid value returns (false, false).
 func (cm *ConfigManagerDefault) GetBoolOK(key string) (bool, bool) {
-	if !cm.Exists(key) {
-		return false, false
-	}
 	val, _, err := cm.Get(key)
 	if err != nil {
 		return false, false
@@ -555,9 +546,6 @@ func (cm *ConfigManagerDefault) GetDuration(key string) (time.Duration, error) {
 // GetDurationOK returns the time.Duration value for the given key and whether
 // the key was set. A present-but-invalid value returns (0, false).
 func (cm *ConfigManagerDefault) GetDurationOK(key string) (time.Duration, bool) {
-	if !cm.Exists(key) {
-		return 0, false
-	}
 	val, _, err := cm.Get(key)
 	if err != nil {
 		return 0, false
@@ -581,9 +569,6 @@ func (cm *ConfigManagerDefault) GetStringSlice(key string) ([]string, error) {
 // GetStringSliceOK returns the []string value for the given key and whether
 // the key was set. A present-but-invalid value returns (nil, false).
 func (cm *ConfigManagerDefault) GetStringSliceOK(key string) ([]string, bool) {
-	if !cm.Exists(key) {
-		return nil, false
-	}
 	val, _, err := cm.Get(key)
 	if err != nil {
 		return nil, false
@@ -604,10 +589,10 @@ func (cm *ConfigManagerDefault) IsSet(ctx context.Context, key string) bool {
 
 // IsSetOK checks if a configuration key exists and has a non-zero value.
 func (cm *ConfigManagerDefault) IsSetOK(key string) bool {
-	if !cm.Exists(key) {
+	val, _, err := cm.Get(key)
+	if err != nil {
 		return false
 	}
-	val, _, _ := cm.Get(key)
 	return !reflect.ValueOf(val).IsZero()
 }
 

--- a/manager.go
+++ b/manager.go
@@ -2,6 +2,7 @@ package configmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/Oudwins/zog"
 	_ "github.com/Oudwins/zog"
@@ -25,6 +26,11 @@ const (
 	keySeparator             = "."
 	ROOT_NS                  = ""
 )
+
+// ErrKeyNotFound is returned when a configuration key does not exist.
+// Use errors.Is(err, ErrKeyNotFound) to distinguish a missing key from other
+// configuration source failures.
+var ErrKeyNotFound = errors.New("configuration key not found")
 
 // copy creates a throwaway copy of the ConfigManagerDefault with a new Koanf instance.
 func (cm *ConfigManagerDefault) copy() *ConfigManagerDefault {
@@ -472,6 +478,19 @@ func (cm *ConfigManagerDefault) GetString(key string) (string, error) {
 	return fmt.Sprintf("%v", val), nil
 }
 
+// GetStringOK returns the string value for the given key and whether the key
+// was set. A present-but-empty value returns ("", true), not ("", false).
+func (cm *ConfigManagerDefault) GetStringOK(key string) (string, bool) {
+	if !cm.Exists(key) {
+		return "", false
+	}
+	val, _, err := cm.Get(key)
+	if err != nil {
+		return "", false
+	}
+	return fmt.Sprintf("%v", val), true
+}
+
 // GetInt returns the int64 value for the given key.
 func (cm *ConfigManagerDefault) GetInt(key string) (int64, error) {
 	val, _, err := cm.Get(key)
@@ -479,6 +498,23 @@ func (cm *ConfigManagerDefault) GetInt(key string) (int64, error) {
 		return 0, err
 	}
 	return cast.ToInt64E(val)
+}
+
+// GetIntOK returns the int64 value for the given key and whether the key was
+// set. A present-but-invalid value returns (0, false).
+func (cm *ConfigManagerDefault) GetIntOK(key string) (int64, bool) {
+	if !cm.Exists(key) {
+		return 0, false
+	}
+	val, _, err := cm.Get(key)
+	if err != nil {
+		return 0, false
+	}
+	i, err := cast.ToInt64E(val)
+	if err != nil {
+		return 0, false
+	}
+	return i, true
 }
 
 // GetBool returns the bool value for the given key.
@@ -490,6 +526,23 @@ func (cm *ConfigManagerDefault) GetBool(key string) (bool, error) {
 	return cast.ToBoolE(val)
 }
 
+// GetBoolOK returns the bool value for the given key and whether the key was
+// set. A present-but-invalid value returns (false, false).
+func (cm *ConfigManagerDefault) GetBoolOK(key string) (bool, bool) {
+	if !cm.Exists(key) {
+		return false, false
+	}
+	val, _, err := cm.Get(key)
+	if err != nil {
+		return false, false
+	}
+	b, err := cast.ToBoolE(val)
+	if err != nil {
+		return false, false
+	}
+	return b, true
+}
+
 // GetDuration returns the time.Duration value for the given key.
 func (cm *ConfigManagerDefault) GetDuration(key string) (time.Duration, error) {
 	val, _, err := cm.Get(key)
@@ -497,6 +550,23 @@ func (cm *ConfigManagerDefault) GetDuration(key string) (time.Duration, error) {
 		return 0, err
 	}
 	return cast.ToDurationE(val)
+}
+
+// GetDurationOK returns the time.Duration value for the given key and whether
+// the key was set. A present-but-invalid value returns (0, false).
+func (cm *ConfigManagerDefault) GetDurationOK(key string) (time.Duration, bool) {
+	if !cm.Exists(key) {
+		return 0, false
+	}
+	val, _, err := cm.Get(key)
+	if err != nil {
+		return 0, false
+	}
+	d, err := cast.ToDurationE(val)
+	if err != nil {
+		return 0, false
+	}
+	return d, true
 }
 
 // GetStringSlice returns the []string value for the given key.
@@ -508,8 +578,32 @@ func (cm *ConfigManagerDefault) GetStringSlice(key string) ([]string, error) {
 	return cast.ToStringSliceE(val)
 }
 
+// GetStringSliceOK returns the []string value for the given key and whether
+// the key was set. A present-but-invalid value returns (nil, false).
+func (cm *ConfigManagerDefault) GetStringSliceOK(key string) ([]string, bool) {
+	if !cm.Exists(key) {
+		return nil, false
+	}
+	val, _, err := cm.Get(key)
+	if err != nil {
+		return nil, false
+	}
+	s, err := cast.ToStringSliceE(val)
+	if err != nil {
+		return nil, false
+	}
+	return s, true
+}
+
 // IsSet checks if a configuration key exists and has a non-zero value.
+// The ctx argument is unused and is retained only for backward compatibility;
+// prefer IsSetOK.
 func (cm *ConfigManagerDefault) IsSet(ctx context.Context, key string) bool {
+	return cm.IsSetOK(key)
+}
+
+// IsSetOK checks if a configuration key exists and has a non-zero value.
+func (cm *ConfigManagerDefault) IsSetOK(key string) bool {
 	if !cm.Exists(key) {
 		return false
 	}
@@ -542,11 +636,10 @@ func (cm *ConfigManagerDefault) Get(key string, target ...any) (any, any, error)
 
 	// Get raw value first
 	if !isRootStructRequest && !cm.koanf.Exists(fullKey) {
-		errMsg := fmt.Sprintf("configuration key '%s' not found", fullKey)
 		if desc := cm.descriptionManager.GetDescription(fullKey); desc != "" {
-			errMsg += fmt.Sprintf(" (%s)", desc)
+			return nil, nil, fmt.Errorf("%w: %s (%s)", ErrKeyNotFound, fullKey, desc)
 		}
-		return nil, nil, fmt.Errorf("%s", errMsg)
+		return nil, nil, fmt.Errorf("%w: %s", ErrKeyNotFound, fullKey)
 	}
 
 	var raw any
@@ -784,6 +877,9 @@ func (cm *ConfigManagerDefault) All() map[string]any {
 }
 
 // Exists checks if a configuration key exists.
+// Exists reports whether a configuration key is present, regardless of whether
+// its value is zero or empty. To distinguish a present-but-empty value from an
+// absent or non-zero one, use IsSetOK or the *OK getter variants.
 func (cm *ConfigManagerDefault) Exists(key string) bool {
 	return cm.koanf.Exists(key)
 }
@@ -1034,7 +1130,7 @@ func (cm *ConfigManagerDefault) Validate(keyPrefix ...string) error {
 		keys := cm.getFilteredKeys(keyPrefix...)
 		if len(keys) == 0 {
 			if len(keyPrefix) == 1 {
-				return fmt.Errorf("configuration key '%s' not found", keyPrefix[0])
+				return fmt.Errorf("%w: %s", ErrKeyNotFound, keyPrefix[0])
 			}
 			return fmt.Errorf("no configuration keys found matching prefixes: %v", keyPrefix)
 		}
@@ -1066,11 +1162,10 @@ func (cm *ConfigManagerDefault) validateConfig(key string) error {
 
 	// First check if the key exists in the configuration
 	if !cm.Exists(key) {
-		errMsg := fmt.Sprintf("configuration key '%s' not found", key)
 		if desc := cm.descriptionManager.GetDescription(key); desc != "" {
-			errMsg += fmt.Sprintf(" (%s)", desc)
+			return fmt.Errorf("%w: %s (%s)", ErrKeyNotFound, key, desc)
 		}
-		return fmt.Errorf("%s", errMsg)
+		return fmt.Errorf("%w: %s", ErrKeyNotFound, key)
 	}
 
 	// Check if we have a registered struct for this key

--- a/manager_test.go
+++ b/manager_test.go
@@ -2799,6 +2799,28 @@ func TestIsSetOK(t *testing.T) {
 	assert.False(t, cm.IsSetOK("missing"))
 }
 
+func TestGetStringOK_NamespaceResolution(t *testing.T) {
+	ns := "app"
+	memSource := source.NewMemoryConfigSource(map[string]any{"port": "8080"})
+
+	cm, err := NewConfigManager([]source.ConfigSource{})
+	require.NoError(t, err)
+	cm.RegisterSource(memSource)
+	cm.RegisterNamespace(ns, memSource)
+	require.NoError(t, cm.LoadNamespace(ns))
+
+	// The OK getters must resolve through the same namespace-aware path as Get.
+	val, ok := cm.GetStringOK(ns + ".port")
+	assert.Equal(t, "8080", val)
+	assert.True(t, ok)
+	assert.True(t, cm.IsSetOK(ns+".port"))
+
+	val, ok = cm.GetStringOK("missing")
+	assert.Equal(t, "", val)
+	assert.False(t, ok)
+	assert.False(t, cm.IsSetOK("missing"))
+}
+
 func TestIsSet_KeepsContextSignature(t *testing.T) {
 	cm := newTestManager()
 	require.NoError(t, cm.Set(context.Background(), "present", "value"))

--- a/manager_test.go
+++ b/manager_test.go
@@ -2693,3 +2693,117 @@ func TestPinnerStyleGetRootNS(t *testing.T) {
 		}
 	}
 }
+
+func TestGet_ErrKeyNotFound(t *testing.T) {
+	cm := newTestManager()
+
+	_, _, err := cm.Get("missing.key")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrKeyNotFound)
+}
+
+func TestGetStringOK(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "name", "alice"))
+	require.NoError(t, cm.Set(context.Background(), "empty", ""))
+
+	val, ok := cm.GetStringOK("name")
+	assert.Equal(t, "alice", val)
+	assert.True(t, ok)
+
+	// Present-but-empty is distinct from absent.
+	val, ok = cm.GetStringOK("empty")
+	assert.Equal(t, "", val)
+	assert.True(t, ok)
+
+	val, ok = cm.GetStringOK("missing")
+	assert.Equal(t, "", val)
+	assert.False(t, ok)
+}
+
+func TestGetIntOK(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "port", 8080))
+	require.NoError(t, cm.Set(context.Background(), "bad", "not-an-int"))
+
+	val, ok := cm.GetIntOK("port")
+	assert.Equal(t, int64(8080), val)
+	assert.True(t, ok)
+
+	// Present but not convertible to int64.
+	val, ok = cm.GetIntOK("bad")
+	assert.Equal(t, int64(0), val)
+	assert.False(t, ok)
+
+	val, ok = cm.GetIntOK("missing")
+	assert.Equal(t, int64(0), val)
+	assert.False(t, ok)
+}
+
+func TestGetBoolOK(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "enabled", true))
+	require.NoError(t, cm.Set(context.Background(), "bad", "not-a-bool"))
+
+	val, ok := cm.GetBoolOK("enabled")
+	assert.True(t, val)
+	assert.True(t, ok)
+
+	val, ok = cm.GetBoolOK("bad")
+	assert.False(t, val)
+	assert.False(t, ok)
+
+	val, ok = cm.GetBoolOK("missing")
+	assert.False(t, val)
+	assert.False(t, ok)
+}
+
+func TestGetDurationOK(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "timeout", 5*time.Second))
+	require.NoError(t, cm.Set(context.Background(), "bad", "not-a-duration"))
+
+	val, ok := cm.GetDurationOK("timeout")
+	assert.Equal(t, 5*time.Second, val)
+	assert.True(t, ok)
+
+	val, ok = cm.GetDurationOK("bad")
+	assert.Equal(t, time.Duration(0), val)
+	assert.False(t, ok)
+
+	val, ok = cm.GetDurationOK("missing")
+	assert.Equal(t, time.Duration(0), val)
+	assert.False(t, ok)
+}
+
+func TestGetStringSliceOK(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "tags", []string{"a", "b"}))
+
+	val, ok := cm.GetStringSliceOK("tags")
+	assert.Equal(t, []string{"a", "b"}, val)
+	assert.True(t, ok)
+
+	val, ok = cm.GetStringSliceOK("missing")
+	assert.Nil(t, val)
+	assert.False(t, ok)
+}
+
+func TestIsSetOK(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "present", "value"))
+	require.NoError(t, cm.Set(context.Background(), "empty", ""))
+
+	assert.True(t, cm.IsSetOK("present"))
+	assert.False(t, cm.IsSetOK("empty"))
+	assert.False(t, cm.IsSetOK("missing"))
+}
+
+func TestIsSet_KeepsContextSignature(t *testing.T) {
+	cm := newTestManager()
+	require.NoError(t, cm.Set(context.Background(), "present", "value"))
+
+	// Legacy signature must still compile and behave identically.
+	assert.True(t, cm.IsSet(context.Background(), "present"))
+	assert.False(t, cm.IsSet(context.Background(), "missing"))
+}


### PR DESCRIPTION
Adds an ErrKeyNotFound sentinel so callers can distinguish a missing key from other configuration source failures via errors.Is, wrapped in Get, Validate, and validateConfig.

Adds GetStringOK, GetIntOK, GetBoolOK, GetDurationOK, and GetStringSliceOK returning (value, ok) for optional values while leaving the existing typed getters unchanged.

Adds IsSetOK for value-presence checks and documents Exists as a key-presence check, retaining the IsSet(ctx, key) signature for backward compatibility.

---

<!-- kody-pr-summary:start -->
## Summary

This pull request introduces `ErrKeyNotFound` sentinel error and new `*OK` getter variants to the configuration manager, enhancing error handling and making it easier to distinguish between missing configuration keys and other failures.

## Key Changes

### 1. New `ErrKeyNotFound` Sentinel Error
- Added a package-level `ErrKeyNotFound` sentinel error (via `errors.New`)
- Updated all "configuration key not found" error paths in `Get`, `Validate`, and `validateConfig` methods to wrap this sentinel using `%w`
- This allows callers to use `errors.Is(err, ErrKeyNotFound)` to reliably detect missing keys, while still including descriptive context (key name and description when available)

### 2. New `*OK` Getter Variants
Added boolean-based variants for all existing typed getters to simplify missing-key detection:

- **`GetStringOK(key) (string, bool)`** - Present-but-empty values return `("", true)`
- **`GetIntOK(key) (int64, bool)`** - Present-but-invalid values return `(0, false)`
- **`GetBoolOK(key) (bool, bool)`** - Present-but-invalid values return `(false, false)`
- **`GetDurationOK(key) (time.Duration, bool)`** - Present-but-invalid values return `(0, false)`
- **`GetStringSliceOK(key) ([]string, bool)`** - Present-but-invalid values return `(nil, false)`

All these variants follow the same pattern: they first check if the key exists, attempt type conversion, and return a boolean indicating whether a valid value was successfully retrieved.

### 3. New `IsSetOK` Method
- Added `IsSetOK(key string) bool` which checks if a key exists and has a non-zero value
- The existing `IsSet(ctx, key)` method now delegates to `IsSetOK` while maintaining its original signature for backward compatibility

### 4. Enhanced Documentation
- Added comprehensive documentation comments for `Exists` clarifying it checks presence only (not value non-emptiness), and directing users to `IsSetOK` or the `*OK` getter variants for value-specific checks
- Updated documentation for `IsSet` noting the context parameter is unused and retained only for backward compatibility

### 5. Test Coverage
Added comprehensive tests for all new functionality:
- `TestGet_ErrKeyNotFound` - verifies `errors.Is` works with the sentinel
- Tests for each `*OK` getter variant covering present, missing, and present-but-invalid scenarios
- Tests confirming backward compatibility of the legacy `IsSet` signature
<!-- kody-pr-summary:end -->